### PR TITLE
[amiwm] remove the global 'front' variable

### DIFF
--- a/client.c
+++ b/client.c
@@ -331,7 +331,7 @@ void flushclients()
   Scrn *scr2;
 #endif
 
-  if((scr = front)) do {
+  if((scr = get_front_scr())) do {
     scr = scr->upfront;
     XQueryTree(dpy, scr->back, &dw1, &dw2, &wins, &nwins);
     for(i=0; i<nwins; i++)
@@ -367,7 +367,7 @@ void flushclients()
       }
       */
     XFree((void *) wins);
-  } while(scr!=front);
+  } while( scr!= get_front_scr());
   while((c=clients)) {
     if(c->parent != c->scr->root) {
       int x,y;

--- a/gram.y
+++ b/gram.y
@@ -103,8 +103,8 @@ stmt		: error
 		| SCREEN string { openscreen($2,DefaultRootWindow(dpy)); }
 		| SCREEN NUMBER string { if(($2==DefaultScreen(dpy)||prefs.manage_all) && $2<ScreenCount(dpy)) openscreen($3,RootWindow(dpy,$2)); }
 		| MODULEPATH string { prefs.module_path = $2; }
-		| MODULE string STRING { create_module((front? front->upfront:NULL), $2, $3); }
-		| MODULE string { create_module((front? front->upfront:NULL), $2, NULL); }
+		| MODULE string STRING { create_module((get_front_scr() ? get_front_scr()->upfront:NULL), $2, $3); }
+		| MODULE string { create_module((get_front_scr() ? get_front_scr()->upfront:NULL), $2, NULL); }
 		| INTERSCREENGAP NUMBER { prefs.borderwidth=$2; }
 		| AUTORAISE truth { prefs.autoraise=$2; }
 		| OPAQUEMOVE truth { prefs.opaquemove=$2; }

--- a/icon.c
+++ b/icon.c
@@ -398,7 +398,7 @@ Icon *createappicon(struct module *m, Window p, char *name,
     scr=c->scr;
   } else
     if(XFindContext(dpy, p, screen_context, (XPointer*)&scr))
-      scr=front;
+      scr = get_front_scr();
   if(p==scr->root) p=scr->back;
 
   i->scr=scr;

--- a/main.c
+++ b/main.c
@@ -540,11 +540,11 @@ void endicondragging(XEvent *e)
   int wx, wy;
   Window ch;
 
-  scr=front;
+  scr=get_front_scr();
   for(;;) {
     if(scr->root == e->xbutton.root && e->xbutton.y_root>=scr->y)
       break;
-    if((scr=scr->behind)==front) {
+    if((scr=scr->behind)==get_front_scr()) {
       badicondrop();
       return;
     }
@@ -823,11 +823,11 @@ static void update_clock(void *dontcare)
   if(server_grabs)
     return;
   call_out(prefs.titleclockinterval, 0, update_clock, dontcare);
-  scr = front;
+  scr = get_front_scr();
   do {
     redrawmenubar(scr->menubar);
     scr=scr->behind;
-  } while(scr!=front);
+  } while(scr != get_front_scr());
 }
 
 void cleanup()
@@ -836,7 +836,7 @@ void cleanup()
   struct coevent *e;
   flushmodules();
   flushclients();
-  scr=front;
+  scr = get_front_scr();
   while(scr)
     closescreen();
   free_prefs();
@@ -981,7 +981,7 @@ int main(int argc, char *argv[])
 	c = NULL;
 	if(XFindContext(dpy, event.xany.window, screen_context,
 			(XPointer*)&scr))
-	  scr=front;
+	  scr = get_front_scr();
       }
       if(XFindContext(dpy, event.xany.window, icon_context, (XPointer*)&i))
 	i=NULL;
@@ -1011,7 +1011,7 @@ int main(int argc, char *argv[])
 
 	if(!event.xcreatewindow.override_redirect) {
 	  if(!(scr=getscreenbyroot(event.xcreatewindow.parent)))
-	    scr=front;
+	    scr = get_front_scr();
 	  createclient(event.xcreatewindow.window);
 	}
 #ifdef ASSIMILATE_WINDOWS
@@ -1178,7 +1178,7 @@ int main(int argc, char *argv[])
       case MapRequest:
 	if(XFindContext(dpy, event.xmaprequest.window, client_context, (XPointer*)&c)) {
 	  if(!(scr=getscreenbyroot(event.xmaprequest.parent)))
-	    scr=front;
+	    scr = get_front_scr();
 	  c=createclient(event.xmaprequest.window);
 	}
 	{

--- a/menu.c
+++ b/menu.c
@@ -805,7 +805,7 @@ void menuaction(struct Item *i, struct Item *si)
     if(item==0) {
       openscreen("New Screen", DefaultRootWindow(dpy));
       realizescreens();
-      scr=front->upfront;
+      scr = get_front_scr()->upfront;
       screentoback();
     }
     if(item==1) {

--- a/module.c
+++ b/module.c
@@ -111,7 +111,7 @@ void delete_keygrab(struct module *m, int id)
 
 static void destroy_module(struct module *m)
 {
-  Scrn *s=front;
+  Scrn *s = get_front_scr();
   delete_keygrab(m, -1);
   do {
     Icon *i, *ni;
@@ -121,7 +121,7 @@ static void destroy_module(struct module *m)
 	rmicon(i);
     }
     s=s->behind;
-  } while(s!=front);
+  } while(s != get_front_scr());
   disown_item_chain(m, m->menuitems);
   if(m->in_fd>=0) { remove_fd_from_set(m->in_fd); close(m->in_fd); }
   if(m->out_fd>=0) { close(m->out_fd); }

--- a/screen.h
+++ b/screen.h
@@ -37,7 +37,10 @@ typedef struct _Scrn {
   unsigned long iconcolor[256];
 } Scrn;
 
-extern Scrn *scr, *front;
+extern Scrn *scr;
+
+Scrn * get_front_scr(void);
+void set_front_scr(Scrn *s);
 
 extern void closescreen();
 extern Scrn * openscreen(char *, Window);


### PR DESCRIPTION
This is a pretty straight forward change to remove the global front
variable and instead use a couple of accessor functions.

This hopefully will make it easier to keep track and debug when
the front screen changes.