### PR TITLE
Ahc 20220425 menu widgets

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -121,3 +121,13 @@ Module "Launcher" "(<label>) (<icon>) (<command and args>)"
 
 The icon is one of the .info icons in the amiwm IconDir.
 
+## Battery module
+
+This is a simple battery state polling module that is being used
+during battery monitoring / menu toolbar development.
+
+It's currently FreeBSD specific and based on what xbatt does
+to pull info from APM/ACPI.  Adding Linux and other OS support
+shouldn't be too difficult.
+
+Module "Battery"

--- a/Makefile.in
+++ b/Makefile.in
@@ -171,6 +171,9 @@ Filesystem : filesystem.o $(LIBAMI)
 Keyboard : kbdmodule.o kbdlexer.o $(LIBAMI)
 	$(CC) -o Keyboard kbdmodule.o kbdlexer.o $(LIBS)
 
+Battery : battery_module.o $(LIBAMI)
+	$(CC) -o Battery battery_module.o $(LIBS)
+
 Launcher : launchermodule.o $(LIBAMI)
 	$(CC) -o Launcher launchermodule.o $(LIBS)
 
@@ -181,7 +184,7 @@ localetest : localetest.o $(LIBAMI)
 	$(CC) -o localetest localetest.o $(LIBS)
 
 clean : lib_clean
-	$(RM) core $(PROGS) $(LIBAMI) Keyboard Launcher *.o
+	$(RM) core $(PROGS) $(LIBAMI) Keyboard Battery Launcher *.o
 	$(RM) lex.yy.c lex.c y.tab.c y.tab.h gram.h gram.c
 	$(RM) kbdlexer.c kbdmodule.h kbdmodule.c
 	$(RM) config.log

--- a/amiwm.1
+++ b/amiwm.1
@@ -94,6 +94,12 @@ The time string is formatted with the standard strftime() parameters.
 The default is "%c".  It has been found that "%a %b %e %Y   %l:%M %p" works
 well too.  Number is the update interval in seconds.  
 
+.SH BatteryInfo {yes|no}
+
+This lets you display battery information on the menu bar.
+It reqiures a module (such as Battery) to gather current battery status
+and push it into amiwm to display.
+
 .SH ToolItem \f1\*(lq\f3name" \f1\*(lq\f3command" \f1\*(lq\f3hotkey"
 
 Adds an item in the Tools menu with the specified name, which executes

--- a/battery_module.c
+++ b/battery_module.c
@@ -38,9 +38,11 @@ get_apm_info(void)
 		return false;
 	}
 
+#if 0
 	printf("Battery life: %d\n", info.ai_batt_life);
 	printf("Battery time: %d\n", info.ai_batt_time);
 	printf("Battery AC: %d\n", info.ai_acline);
+#endif
 
 	md_update_battery(info.ai_batt_life, info.ai_batt_time,
 	    info.ai_acline);
@@ -51,15 +53,16 @@ get_apm_info(void)
 static void
 periodic_func(void)
 {
-	fprintf(stderr, "Ha!\n");
 	get_apm_info();
 }
 
-int main(int argc, char *argv[])
+int
+main(int argc, char *argv[])
 {
   char *arg;
 
   arg = md_init(argc, argv);
+  (void) arg;
 
   progname=argv[0];
 
@@ -73,6 +76,7 @@ int main(int argc, char *argv[])
   /* initial battery info */
   get_apm_info();
 
+  /* Run main loop */
   md_main_loop();
 
   close(apm_fd);

--- a/battery_module.c
+++ b/battery_module.c
@@ -11,6 +11,9 @@
 
 #include "libami.h"
 
+/* XXX should be an md method */
+extern void (*md_periodic_func)(void);
+
 /*
  * Test battery module for FreeBSD, using APM.
  */
@@ -45,21 +48,29 @@ get_apm_info(void)
 	return true;
 }
 
+static void
+periodic_func(void)
+{
+	fprintf(stderr, "Ha!\n");
+	get_apm_info();
+}
+
 int main(int argc, char *argv[])
 {
-  char *arg=md_init(argc, argv);
+  char *arg;
+
+  arg = md_init(argc, argv);
 
   progname=argv[0];
+
+  md_periodic_func = periodic_func;
 
   apm_fd = open(APM_DEV, O_RDONLY);
   if (apm_fd < 0) {
     err(127, "open");
   }
 
-  /*
-   * XXX TODO: how do I actually get this to run once
-   * a second in the main loop?
-   */
+  /* initial battery info */
   get_apm_info();
 
   md_main_loop();

--- a/battery_module.c
+++ b/battery_module.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+#include <err.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <machine/apm_bios.h>
+
+#define APM_DEV "/dev/apm"
+
+#include "libami.h"
+
+/*
+ * Test battery module for FreeBSD, using APM.
+ */
+
+void docmd(XEvent *e, void *callback)
+{
+  ((void (*)(Window))callback)(e->xany.window);
+}
+
+static char *progname;
+static int apm_fd = -1;
+
+static bool
+get_apm_info(void)
+{
+	int ret;
+	struct apm_info info;
+
+	ret = ioctl(apm_fd, APMIO_GETINFO, &info);
+	if (ret < 0) {
+		warn("ioctl (APMIO_GETINFO)");
+		return false;
+	}
+
+	printf("Battery life: %d\n", info.ai_batt_life);
+	printf("Battery time: %d\n", info.ai_batt_time);
+	printf("Battery AC: %d\n", info.ai_acline);
+
+	md_update_battery(info.ai_batt_life, info.ai_batt_time,
+	    info.ai_acline);
+
+	return true;
+}
+
+int main(int argc, char *argv[])
+{
+  char *arg=md_init(argc, argv);
+
+  progname=argv[0];
+
+  apm_fd = open(APM_DEV, O_RDONLY);
+  if (apm_fd < 0) {
+    err(127, "open");
+  }
+
+  /*
+   * XXX TODO: how do I actually get this to run once
+   * a second in the main loop?
+   */
+  get_apm_info();
+
+  md_main_loop();
+
+  close(apm_fd);
+  return 0;
+}

--- a/gram.y
+++ b/gram.y
@@ -66,6 +66,7 @@ static int ti_level=0;
 %token <num> INTERSCREENGAP AUTORAISE FOCUS FOLLOWMOUSE CLICKTOTYPE SLOPPY
 %token <num> CUSTOMICONSONLY
 %token <num> TITLEBARCLOCK TITLECLOCKFORMAT
+%token <num> BATTERYINFO
 %token <num> OPAQUEMOVE OPAQUERESIZE SCREENMENU STYLE CLASS TITLE ICONTITLE ICON
 %token <num> SHORTLABELICONS
 %token <ptr> STRING
@@ -118,6 +119,7 @@ stmt		: error
 					prefs.titleclockinterval=$2; 
 					prefs.titleclockformat=$3; }
 		| SCREENMENU truth { prefs.screenmenu=$2; }
+		| BATTERYINFO truth { prefs.battery_info = $2; }
 		| stylespec styleitems RIGHTBRACE
 		;
 

--- a/libami/Makefile.in
+++ b/libami/Makefile.in
@@ -19,12 +19,12 @@ LN_S = @LN_S@
 RM = -rm -f
 
 OBJS  = drawinfo.o module.o broker.o eventdispatcher.o mdscreen.o \
-	mdicon.o mdwindow.o kbdsupport.o hotkey.o \
+	mdicon.o mdwindow.o kbdsupport.o hotkey.o mdbattery.o \
 	lists.o readargs.o iconlib.o iconutil.o error.o strutil.o \
 	iffparse.o gadget_button.o gadget_textbox.o gadget_textinput.o
 
 SRCS = drawinfo.c module.c broker.c eventdispatcher.c mdscreen.c \
-	mdicon.c mdwindow.c kbdsupport.c hotkey.c \
+	mdicon.c mdwindow.c kbdsupport.c hotkey.c mdbattery.c \
 	lists.c readargs.c iconlib.c iconutil.c error.c strutil.c \
 	iffparse.c gadget_button.c gadget_textbox.c gadget_textinput.c
 

--- a/libami/libami.h
+++ b/libami/libami.h
@@ -389,6 +389,9 @@ extern Pixmap md_image_to_pixmap(Window, unsigned long, struct Image *,
 				 int, int, struct ColorStore *);
 extern char *get_current_icondir(void);
 
+/* mdbattery.c */
+extern void md_update_battery(int pct, int time, int ac);
+
 /* mdwindow.c */
 extern int md_set_appwindow(Window);
 

--- a/libami/mdbattery.c
+++ b/libami/mdbattery.c
@@ -1,0 +1,85 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "libami.h"
+#include "module.h"
+#include "alloc.h"
+
+void
+md_update_battery(int pct, int time, int ac)
+{
+	struct mcmd_update_battery batt = { 0 };
+	int res;
+
+	batt.battery_time = time;
+	batt.battery_pct = pct;
+	batt.battery_ac = ac;
+
+	res = md_command0(None, MCMD_UPDATE_BATTERY, &batt, sizeof(batt));
+	(void) res;
+}
+
+Window md_create_appicon(Window p, int x, int y, char *name,
+			 Pixmap pm1, Pixmap pm2, Pixmap pmm)
+{
+  char *data;
+  Window w;
+  int res, l=strlen(name);
+#ifdef HAVE_ALLOCA
+  struct NewAppIcon *nai=alloca(sizeof(struct NewAppIcon)+l);
+#else
+  struct NewAppIcon *nai=malloc(sizeof(struct NewAppIcon)+l);
+  if(nai==NULL) return None;
+#endif
+  nai->x=x; nai->y=y;
+  nai->pm1=pm1; nai->pm2=pm2; nai->pmm=pmm;
+  strcpy(nai->name, name);
+  res=md_command(p, MCMD_CREATEAPPICON, nai, sizeof(struct NewAppIcon)+l,
+		 &data);
+  if(res<sizeof(w)) {
+    if(data) free(data);
+#ifndef HAVE_ALLOCA
+    free(nai);
+#endif
+    return None;
+  }
+  memcpy(&w, data, sizeof(w));
+  free(data);
+#ifndef HAVE_ALLOCA
+  free(nai);
+#endif
+  return w;
+}
+
+Pixmap md_image_to_pixmap(Window w, unsigned long bgcolor, struct Image *i,
+			  int width, int height, struct ColorStore *cs)
+{
+  Display *dpy = md_display();
+  static GC gc = None;
+  Pixmap pm;
+  static int iconcolormask;
+  static unsigned long *iconcolor = NULL;
+  if(gc == None && w != None)
+    gc = XCreateGC(dpy, w, 0, NULL);
+  if(iconcolor == NULL) {
+    char *p;
+    int res = md_command(w, MCMD_GETICONPALETTE, NULL, 0, &p);
+    if(res<0)
+      return None;
+    iconcolor = (unsigned long *)(void *)p;
+    iconcolormask = (res/sizeof(unsigned long))-1;
+  }
+  pm = image_to_pixmap(md_display(), w, gc, bgcolor, iconcolor, iconcolormask,
+		       i, width, height, cs);
+  return pm;
+}
+
+char *get_current_icondir()
+{
+  char *p;
+  if(md_command(None, MCMD_GETICONDIR, NULL, 0, &p)>=0 && p)
+    return p;
+  if(p) free(p);
+  return NULL;
+}
+

--- a/main.c
+++ b/main.c
@@ -820,9 +820,12 @@ void internal_broker(XEvent *e)
 
 static void update_clock(void *dontcare)
 {
+  Scrn *scr;
+
   if(server_grabs)
     return;
   call_out(prefs.titleclockinterval, 0, update_clock, dontcare);
+
   scr = get_front_scr();
   do {
     redrawmenubar(scr->menubar);

--- a/menu.c
+++ b/menu.c
@@ -37,6 +37,8 @@ extern struct Library *XLibBase;
 #define CHECKED 2
 #define DISABLED 4
 
+char battery_status[128];
+
 extern Display *dpy;
 extern Cursor wm_curs;
 extern XContext screen_context, client_context;
@@ -303,7 +305,7 @@ void redraw_item(struct Item *i, Window w)
     XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[BARDETAILPEN]);
     XSetBackground(dpy, scr->menubargc, scr->dri.dri_Pens[BARBLOCKPEN]);
   }
-  if(i->text)
+  if(i->text) {
 #ifdef USE_FONTSETS
     XmbDrawImageString(dpy, w, scr->dri.dri_FontSet,
 		       scr->menubargc, (i->flags&CHECKIT)?1+scr->checkmarkspace:1,
@@ -312,8 +314,9 @@ void redraw_item(struct Item *i, Window w)
     XDrawImageString(dpy, w, scr->menubargc, (i->flags&CHECKIT)?1+scr->checkmarkspace:1,
 		     scr->dri.dri_Ascent+1, i->text, i->textlen);
 #endif
-  else
+  } else {
     XFillRectangle(dpy, w, scr->menubargc, 2, 2, m->width-10, 2);
+  }
   if(i->sub) {
     int x=m->width-6-scr->hotkeyspace-1+8;
 #ifdef USE_FONTSETS
@@ -547,11 +550,11 @@ void redrawmenubar(Window w)
     /*
      * Update the battery indicator if it's enabled.
      */
-    if (1) {
+    if (prefs.battery_info) {
       char battery_buf[512];
       int l;
 
-      sprintf(battery_buf, "| Battery |");
+      sprintf(battery_buf, "| %s |", battery_status);
 #ifdef USE_FONTSETS
       l = XmbTextEscapement(scr->dri.dri_FontSet, battery_buf, strlen(battery_buf));
       XmbDrawImageString(dpy, w, scr->dri.dri_FontSet, scr->menubargc,

--- a/module.c
+++ b/module.c
@@ -493,19 +493,34 @@ static void handle_module_cmd(struct module *m, char *data, int data_len)
   case MCMD_UPDATE_BATTERY:
     {
         struct mcmd_update_battery *batt;
+        extern char battery_status[];
+
+        if (data == NULL) {
+          reply_module(m, NULL, -1);
+          break;
+        }
         if (data_len != sizeof(struct mcmd_update_battery)) {
           reply_module(m, NULL, -1);
           break;
         }
         batt = (void *) data;
 
+#if 0
         fprintf(stderr, "%s: called, BATTERY, pct=%d, time=%d, ac=%d\n",
             __func__,
             batt->battery_pct,
             batt->battery_time,
             batt->battery_ac);
+#endif
 
-        /* XXX TODO: update the battery menu thingy here */
+        /*
+         * XXX TODO: for now we're just populating a string here.
+         * Later on we should just store the current battery state
+         * somewhere (a key/value table would be nice!) and then
+         * the widget code can pull out its needed state to render.
+         */
+        snprintf(battery_status, 128, "%d pct%s", batt->battery_pct,
+            batt->battery_ac == 1 ? " A" : " -");
 
         reply_module(m, NULL, 0);
         break;

--- a/module.c
+++ b/module.c
@@ -490,6 +490,27 @@ static void handle_module_cmd(struct module *m, char *data, int data_len)
     } else
       reply_module(m, NULL, -1);
     break;
+  case MCMD_UPDATE_BATTERY:
+    {
+        struct mcmd_update_battery *batt;
+        if (data_len != sizeof(struct mcmd_update_battery)) {
+          reply_module(m, NULL, -1);
+          break;
+        }
+        batt = (void *) data;
+
+        fprintf(stderr, "%s: called, BATTERY, pct=%d, time=%d, ac=%d\n",
+            __func__,
+            batt->battery_pct,
+            batt->battery_time,
+            batt->battery_ac);
+
+        /* XXX TODO: update the battery menu thingy here */
+
+        reply_module(m, NULL, 0);
+        break;
+    }
+    break;
   default:
     reply_module(m, NULL, -1);
   }

--- a/module.h
+++ b/module.h
@@ -16,6 +16,7 @@
 #define MCMD_MANAGEMENU 18
 #define MCMD_ROTATE_WINDOW_RAISE 19
 #define MCMD_ROTATE_WINDOW_LOWER 20
+#define MCMD_UPDATE_BATTERY 21
 
 struct mcmd_header {
   XID id;
@@ -40,6 +41,14 @@ struct NewAppIcon {
   int x, y;
   Pixmap pm1, pm2, pmm;
   char name[1];
+};
+
+struct mcmd_update_battery {
+  int battery_time;
+  int battery_pct;
+  int battery_cap;
+  int battery_ac;
+  int battery_charging;
 };
 
 extern struct module {

--- a/prefs.h
+++ b/prefs.h
@@ -17,6 +17,7 @@ extern struct prefs_struct {
   char *titleclockformat;		/* format to use for the clock */
   int titleclockinterval;		/* how often do we update the clock?*/
   int icontray;				// if true then icons will be shown in a tray on top of each screen (besides clock and screen name)
+  int battery_info;			/* display battery info? */
   struct _Style *firststyle, *laststyle;
 } prefs;
 

--- a/rc.c
+++ b/rc.c
@@ -105,6 +105,7 @@ struct keyword { char *name; int token; } keywords[] = {
   { "barblockpen", T_BARBLOCKPEN },
   { "bardetailpen", T_BARDETAILPEN },
   { "bartrimpen", T_BARTRIMPEN },
+  { "batteryinfo", BATTERYINFO },
   { "blockpen", T_BLOCKPEN },
   { "both", BOTH },
   { "bottom", BOTTOM },


### PR DESCRIPTION
Add support for a freebsd specific battery widget on the menu bar, and make the module IO loop non-blocking so modules can do some periodic work rather than only when they receive a notification from amiwm.

This works OK as a proof of concept and I'd rather get it into the tree for others to play with whilst I look at
other bits of amiwm to clean up to make this, well, cleaner!