### PR TITLE
Correct filenames for README and MODULES

### DIFF
--- a/Imakefile
+++ b/Imakefile
@@ -67,7 +67,7 @@ InstallNonExec(def_tool.info, $(AMIWM_HOME)/def_tool.info)
 
 /*  Targets for my private use.  Not very portable.   // Marcus  */
 
-DISTFILES = README INSTALL Imakefile smakefile scoptions *.[chly] \
+DISTFILES = README.md INSTALL Imakefile smakefile scoptions *.[chly] \
 	system.amiwmrc def_tool.info
 
 patch :

--- a/Makefile.in
+++ b/Makefile.in
@@ -38,7 +38,7 @@ SRCS = main.c screen.c client.c frame.c icc.c \
 		requestchoice.c executecmd.c kbdmodule.c kbdlexer.c \
 		config_util.c launchermodule.c
 
-DISTFILES = README README.modules INSTALL LICENSE amiwm.1 \
+DISTFILES = README.md MODULES.md INSTALL LICENSE amiwm.1 \
 	configure configure.in Makefile.in install-sh smakefile scoptions \
 	*.[chly] system.amiwmrc def_*.info *.map \
 	Background Background_resize Background_resize_norepeat \

--- a/amiwm.1
+++ b/amiwm.1
@@ -134,7 +134,7 @@ shared amongst different architectures.
 Start a module with the specified name.  If initstring is specified, it
 is sent to the module.  There are currently two modules shipped with
 amiwm; Background and Keyboard.  These are documented in the file
-README.modules.  If a module is limited to a single screen, like the
+MODULES.md.  If a module is limited to a single screen, like the
 Background module, the screen that was created last is used.
 
 .SH InterScreenGap number


### PR DESCRIPTION
The README file in this repo is called README.md and the old
README.modules is now named MODULES.md. Changed references to those
files (including in the man page) to reflect what is in the repo today.