### PR TITLE
refactoring: localize global state by implementing nested event loops

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,7 +29,7 @@ MODULES = Background Keyboard Background_resize Background_stretch \
 
 OBJS  = main.o screen.o client.o frame.o icc.o \
 		icon.o menu.o diskobject.o gram.tab.o lex.o rc.o \
-		module.o
+		module.o events.o
 
 SRCS = main.c screen.c client.c frame.c icc.c \
 		icon.c menu.c diskobject.c gram.tab.c lex.c rc.c \

--- a/client.c
+++ b/client.c
@@ -4,12 +4,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
+#include "drawinfo.h"
 #include "icc.h"
+#include "icon.h"
 #include "prefs.h"
+#include "screen.h"
 
 #ifdef AMIGAOS
 #include <pragmas/xlib_pragmas.h>
@@ -19,7 +19,6 @@ extern struct Library *XLibBase;
 extern Display *dpy;
 extern XContext client_context, screen_context;
 extern Client *activeclient;
-extern Scrn *menuactive;
 extern void setfocus(Window);
 
 Client *clients=NULL;
@@ -322,8 +321,6 @@ void rmclient(Client *c)
       closescreen();
     scr = c->scr;
     if(c->active) {
-      if(!menuactive)
-	setfocus(None);
       c->active=False;
       activeclient = NULL;
       XInstallColormap(dpy, scr->cmap);

--- a/diskobject.c
+++ b/diskobject.c
@@ -13,6 +13,7 @@
 
 #include "alloc.h"
 #include "drawinfo.h"
+#include "diskobject.h"
 #include "prefs.h"
 #include "screen.h"
 #include "libami.h"

--- a/diskobject.h
+++ b/diskobject.h
@@ -1,0 +1,1 @@
+extern void init_iconpalette(void);

--- a/events.c
+++ b/events.c
@@ -1,0 +1,267 @@
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <X11/Xlib.h>
+#ifdef AMIGAOS
+#include <x11/xtrans.h>
+#endif
+
+#include "client.h"
+#include "events.h"
+#include "frame.h"
+#include "icon.h"
+#include "menu.h"
+#include "module.h"
+#include "screen.h"
+
+#ifdef BSD_STYLE_GETTIMEOFDAY
+#define GETTIMEOFDAY(tp) gettimeofday(tp, NULL)
+#else
+#define GETTIMEOFDAY(tp) gettimeofday(tp)
+#endif
+#define FIXUPTV(tv) { \
+    while((tv).tv_usec<0) { (tv).tv_usec+=1000000; (tv).tv_sec--; } \
+    while((tv).tv_usec>=1000000) { (tv).tv_usec-=1000000; (tv).tv_sec++; } \
+}
+
+struct coevent *eventlist=NULL;
+
+fd_set master_fd_set;
+int max_fd=0;
+
+extern Display *dpy;
+extern XContext client_context, icon_context, screen_context;
+
+static void restorescreentitle(Scrn *s)
+{
+  (scr=s)->title=s->deftitle;
+  XClearWindow(dpy, s->menubar);
+  redrawmenubar(s, s->menubar);
+  if(free_screentitle) {
+    free(free_screentitle);
+    free_screentitle=NULL;
+  }
+}
+
+static void handle_other_events(void)
+{
+  fd_set rfds = master_fd_set;
+  struct timeval t = {
+    .tv_sec = 0,
+    .tv_usec = 0,
+  };
+
+  if (select(max_fd, &rfds, NULL, NULL, &t) > 0) {
+    handle_module_input(&rfds);
+    if(FD_ISSET(ConnectionNumber(dpy), &rfds))
+      XFlush(dpy);
+    return;
+  }
+  XFlush(dpy);
+  rfds = master_fd_set;
+  if (eventlist)
+    fill_in_call_out(&t);
+  if (select(max_fd, &rfds, NULL, NULL, (eventlist? &t:NULL))<0) {
+    if (errno != EINTR) {
+      perror("select");
+      return;
+    }
+  } else {
+    call_call_out();
+    handle_module_input(&rfds);
+    if(FD_ISSET(ConnectionNumber(dpy), &rfds))
+      XFlush(dpy);
+  }
+}
+
+static Bool filter_event(XEvent *event)
+{
+  Client *c = NULL;
+  Icon *i = NULL;
+  Scrn *s = NULL;
+
+  switch (event->type) {
+  case Expose:
+    if (event->xexpose.count)
+      return True;
+    else if (!XFindContext(dpy, event->xexpose.window, client_context, (XPointer*)&c))
+      redraw(c, event->xexpose.window);
+    else if (!XFindContext(dpy, event->xexpose.window, icon_context, (XPointer*)&i))
+      redrawicon(i, event->xexpose.window);
+    else if (!XFindContext(dpy, event->xexpose.window, screen_context, (XPointer*)&s))
+      redrawmenubar(s, event->xexpose.window);
+    return True;
+  case KeyPress:
+    if(!dispatch_event_to_broker(event, KeyPressMask, modules))
+      internal_broker(event);
+    return True;
+  case KeyRelease:
+    if(!dispatch_event_to_broker(event, KeyPressMask, modules))
+      internal_broker(event);
+    return True;
+  case MappingNotify:
+    if(!dispatch_event_to_broker(event, 0, modules))
+      internal_broker(event);
+    return True;
+  case MotionNotify:
+    compress_motion(event);
+    return False;  /* motion events are filtered; but caller must still handle it */
+  default:
+    return False;  /* unfiltered event; caller must handle it */
+  }
+}
+
+void add_fd_to_set(int fd)
+{
+  FD_SET(fd, &master_fd_set);
+  if(fd>=max_fd)
+    max_fd=fd+1;
+}
+
+void remove_fd_from_set(int fd)
+{
+  FD_CLR(fd, &master_fd_set);
+}
+
+void call_out(int howlong_s, int howlong_u, void (*what)(void *), void *with)
+{
+  struct coevent *ce=malloc(sizeof(struct coevent));
+  if(ce) {
+    struct coevent **e=&eventlist;
+    GETTIMEOFDAY(&ce->when);
+    ce->when.tv_sec+=howlong_s;
+    ce->when.tv_usec+=howlong_u;
+    FIXUPTV(ce->when);
+    ce->what=what;
+    ce->with=with;
+    while(*e && ((*e)->when.tv_sec<ce->when.tv_sec ||
+		 ((*e)->when.tv_sec==ce->when.tv_sec &&
+		  (*e)->when.tv_usec<=ce->when.tv_usec)))
+      e=&(*e)->next;
+    ce->next=*e;
+    *e=ce;
+  }
+}
+
+void remove_call_out(void (*what)(void *), void *with)
+{
+  struct coevent *ee, **e=&eventlist;
+
+  while(*e && ((*e)->what != what || (*e)->with != with))
+    e=&(*e)->next;
+  if((ee=*e)) {
+    *e=(*e)->next;
+    free(ee);
+  }
+}
+
+void fill_in_call_out(struct timeval *tv)
+{
+  GETTIMEOFDAY(tv);
+  tv->tv_sec=eventlist->when.tv_sec-tv->tv_sec;
+  tv->tv_usec=eventlist->when.tv_usec-tv->tv_usec;
+  FIXUPTV(*tv);
+  if(tv->tv_sec<0)
+    tv->tv_sec = tv->tv_usec = 0;
+}
+
+void call_call_out(void)
+{
+  struct timeval now;
+  struct coevent *e;
+  GETTIMEOFDAY(&now);
+  FIXUPTV(now);
+  while((e=eventlist) && (e->when.tv_sec<now.tv_sec ||
+			  (e->when.tv_sec==now.tv_sec &&
+			   e->when.tv_usec<=now.tv_usec))) {
+    eventlist=e->next;
+    (e->what)(e->with);
+    free(e);
+  }
+}
+
+void wberror(Scrn *s, char *message)
+{
+  remove_call_out((void(*)(void *))restorescreentitle, s);
+  (scr=s)->title=message;
+  XClearWindow(dpy, s->menubar);
+  redrawmenubar(s, s->menubar);
+  XBell(dpy, 100);
+  call_out(2, 0, (void(*)(void *))restorescreentitle, s);
+}
+
+void compress_motion(XEvent *event)
+{
+  if (event->type != MotionNotify)
+    return;
+  while (XCheckTypedWindowEvent(dpy, event->xmotion.window, MotionNotify, event))
+    ;
+}
+
+Bool grab_for_motion(Window w, Window confine, Cursor curs, Time time, int x_root, int y_root)
+{
+  /*
+   * To avoid misclicks, only grab for move/resize/etc, if the user has
+   * moved the pointer by a given threshold.
+   */
+  static const int THRESHOLD = 5;
+  int status;
+
+  XSync(dpy, False);
+  status = XGrabPointer(dpy, w, False,
+                        ButtonPressMask|ButtonReleaseMask|Button1MotionMask,
+                        GrabModeAsync, GrabModeAsync, confine, None, time);
+  if (status == AlreadyGrabbed || status == GrabSuccess) {
+    for (;;) {
+      XEvent event;
+      int dx, dy;
+
+      XMaskEvent(dpy, ButtonPressMask|ButtonReleaseMask|Button1MotionMask, &event);
+      XPutBackEvent(dpy, &event);
+      if (event.type != MotionNotify)
+        break;
+      compress_motion(&event);
+      dx = x_root - event.xmotion.x_root;
+      dy = y_root - event.xmotion.y_root;
+      if (dx*dx + dy*dy > THRESHOLD*THRESHOLD) /* Pythagoras! */
+        return True;
+    }
+  }
+  XUngrabPointer(dpy, CurrentTime);
+  return False;
+}
+
+XEvent get_drag_event(void)
+{
+  for (;;) {
+    XEvent event;
+    while (XCheckMaskEvent(
+      dpy, ExposureMask | ButtonPressMask | ButtonReleaseMask |
+      PointerMotionMask | EnterWindowMask | LeaveWindowMask, &event
+    )) {
+      if (!filter_event(&event))
+        return event;
+    }
+    handle_other_events();
+  }
+}
+
+XEvent get_next_event(void)
+{
+  for (;;) {
+    XEvent event;
+    while (XPending(dpy) > 0) {
+      XNextEvent(dpy, &event);
+      if (!filter_event(&event))
+        return event;
+    }
+    handle_other_events();
+  }
+}

--- a/events.h
+++ b/events.h
@@ -1,0 +1,36 @@
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#ifdef AMIGAOS
+#include <pragmas/xlib_pragmas.h>
+extern struct Library *XLibBase;
+
+struct timeval {
+  long tv_sec;
+  long tv_usec;
+};
+#endif
+
+struct _Scrn;
+
+XEvent get_drag_event(void);
+XEvent get_next_event(void);
+Bool grab_for_motion(Window w, Window confine, Cursor curs, Time time, int x_root, int y_root);
+void add_fd_to_set(int fd);
+void compress_motion(XEvent *event);
+void remove_fd_from_set(int fd);
+void wberror(struct _Scrn *s, char *message);
+
+void call_call_out(void);
+void call_out(int howlong_s, int howlong_u, void (*what)(void *), void *with);
+void remove_call_out(void (*what)(void *), void *with);
+void fill_in_call_out(struct timeval *tv);
+
+extern int max_fd;
+extern fd_set master_fd_set;
+extern struct coevent {
+  struct coevent *next;
+  struct timeval when;
+  void (*what)(void *);
+  void *with;
+} *eventlist;

--- a/frame.c
+++ b/frame.c
@@ -10,6 +10,9 @@
 
 #include "drawinfo.h"
 #include "screen.h"
+#include "menu.h"
+#include "events.h"
+#include "frame.h"
 #include "icon.h"
 #include "client.h"
 #include "icc.h"
@@ -28,7 +31,6 @@ extern Display *dpy;
 extern XContext client_context, screen_context;
 extern Cursor wm_curs;
 extern int shape_extn;
-extern void redrawmenubar(Scrn *, Window);
 void reshape_frame(Client *c);
 
 Window creategadget(Client *c, Window p, int x, int y, int w, int h)
@@ -511,51 +513,6 @@ void redrawclient(Client *c)
     redraw(c, c->resize);
 }
 
-extern Client *clickclient;
-extern Window clickwindow;
-extern Scrn *mbdclick, *mbdscr;
-
-void clickenter()
-{
-  if((scr=mbdscr)&& clickwindow == scr->menubardepth) {
-    mbdclick = scr;
-    redrawmenubar(scr, scr->menubardepth);
-  } else {
-    scr = clickclient->scr;
-    redraw(clickclient, clickclient->clicked=clickwindow);
-  }
-}
-
-void clickleave()
-{
-  if((scr=mbdscr)&& clickwindow == scr->menubardepth) {
-    mbdclick = NULL;
-    redrawmenubar(scr, scr->menubardepth);
-  } else {
-    scr = clickclient->scr;
-    clickclient->clicked=None;
-    redraw(clickclient, clickwindow);
-  }
-}
-
-void gadgetclicked(Client *c, Window w, XEvent *e)
-{
-  scr=c->scr;
-  redraw(c, clickwindow=(clickclient=c)->clicked=w);
-}
-
-void gadgetaborted(Client *c)
-{
-  Window w;
-  scr=c->scr;
-  if((w=c->clicked)) {
-    c->clicked=None;
-    redraw(c, w);
-  }
-  clickwindow=None;
-  clickclient=NULL;
-}
-
 static Client *topmostmappedclient(Window *children, unsigned int nchildren)
 {
   int n;
@@ -726,37 +683,91 @@ raisebottommostclient(Scrn *scr)
 		XFree(children);
 }
 
-
-void gadgetunclicked(Client *c, XEvent *e)
+static Bool is_inside(int x0, int y0, int w, int h, int x, int y)
 {
-  extern void adjusticon(Icon *);
-  Window w;
-  scr=c->scr;
-  if((w=c->clicked)) {
-    c->clicked=None;
-    redraw(c, w);
-    if(w==c->close) {
-      if((c->proto & Pdelete)&&!(e->xbutton.state&ShiftMask))
-	sendcmessage(c->window, ATOMS[WM_PROTOCOLS], ATOMS[WM_DELETE_WINDOW]);
-      else
-	XKillClient(dpy, c->window);
-    } else if(w==c->depth)
-      raiselowerclient(c, -1);
-    else if(w==c->zoom) {
-      XWindowAttributes xwa;
-      XGetWindowAttributes(dpy, c->parent, &xwa);
-      XMoveWindow(dpy, c->parent, c->x=c->zoomx, c->y=c->zoomy);
-      resizeclientwindow(c, c->zoomw+c->framewidth, c->zoomh+c->frameheight);
-      c->zoomx=xwa.x;
-      c->zoomy=xwa.y;
-      c->zoomw=xwa.width-c->framewidth;
-      c->zoomh=xwa.height-c->frameheight;
-/*      XWarpPointer(dpy, None, c->zoom, 0, 0, 0, 0, 23/2, scr->h5);  */
-      sendconfig(c);
-    } else if(w==c->iconify) {
-      iconify(c);
+  if (w == 0 || h == 0)
+    return True;  /* caller do not care about where click got released */
+  return x >= x0 && y >= y0 && x < x0 + w && y < y0 + h;
+}
+
+enum click {
+  CLICK_OUT = 0,        /* click failed or released outside button */
+  CLICK_IN  = 1,        /* click released inside button */
+  CLICK_ALT = 2,        /* click released inside button, while Shift pressed */
+};
+
+/* check if Button1 is pressed AND released with cursor inside window */
+static enum click got_clicked(Client *c, Window w, Cursor curs, Time time)
+{
+  XWindowAttributes xwa;
+  int status;
+
+  XSync(dpy, False);
+  if (!XGetWindowAttributes(dpy, w, &xwa))
+    return CLICK_OUT;
+  status = XGrabPointer(dpy, w, True, ButtonPressMask|ButtonReleaseMask,
+                        GrabModeAsync, GrabModeAsync, False, curs, time);
+  if (status != AlreadyGrabbed && status != GrabSuccess)
+    return CLICK_OUT;
+  c->clicked = w;
+  redraw(c, w);
+  for (;;) {
+    XEvent event;
+
+    event = get_drag_event();
+    if (event.type == ButtonRelease || event.type == ButtonPress) {
+      c->clicked = None;
+      redraw(c, w);
+      XUngrabPointer(dpy, event.xbutton.time);
+      if (event.type == ButtonPress)
+        return CLICK_OUT;
+      if (event.xbutton.button != Button1)
+        return CLICK_OUT;
+      if (!is_inside(0, 0, xwa.width, xwa.height, event.xbutton.x, event.xbutton.y))
+        return CLICK_OUT;
+      if (event.xbutton.button & ShiftMask)
+        return CLICK_ALT;
+      return CLICK_IN;
     }
   }
-  clickwindow=None;
-  clickclient=NULL;
+}
+
+void click_close(Client *c, Time time)
+{
+  enum click click = got_clicked(c, c->close, None, time);
+  if (click == CLICK_OUT)
+    return;
+  else if ((c->proto & Pdelete) && click != CLICK_ALT)
+    sendcmessage(c->window, ATOMS[WM_PROTOCOLS], ATOMS[WM_DELETE_WINDOW]);
+  else
+    XKillClient(dpy, c->window);
+}
+
+void click_depth(Client *c, Time time)
+{
+  if (got_clicked(c, c->depth, None, time)) {
+    raiselowerclient(c, -1);
+  }
+}
+
+void click_zoom(Client *c, Time time)
+{
+  if (got_clicked(c, c->zoom, None, time)) {
+    XWindowAttributes xwa;
+    XGetWindowAttributes(dpy, c->parent, &xwa);
+    XMoveWindow(dpy, c->parent, c->x=c->zoomx, c->y=c->zoomy);
+    resizeclientwindow(c, c->zoomw+c->framewidth, c->zoomh+c->frameheight);
+    c->zoomx=xwa.x;
+    c->zoomy=xwa.y;
+    c->zoomw=xwa.width-c->framewidth;
+    c->zoomh=xwa.height-c->frameheight;
+    sendconfig(c);
+  }
+}
+
+void click_iconify(Client *c, Time time)
+{
+  if (got_clicked(c, c->iconify, None, time)) {
+    iconify(c);
+  }
 }

--- a/frame.h
+++ b/frame.h
@@ -1,0 +1,12 @@
+struct _Client;
+
+extern void click_close(struct _Client *c, Time time);
+extern void click_depth(struct _Client *c, Time time);
+extern void click_iconify(struct _Client *c, Time time);
+extern void click_zoom(struct _Client *c, Time time);
+extern void raiselowerclient(struct _Client *c, int place);
+extern void redraw(struct _Client *c, Window w);
+extern void redrawclient(struct _Client *c);
+extern void reparent(struct _Client *c);
+extern void reshape_frame(struct _Client *c);
+extern void resizeclientwindow(struct _Client *c, int width, int height);

--- a/icc.c
+++ b/icc.c
@@ -1,11 +1,12 @@
 #include <X11/Xatom.h>
 
 #include "drawinfo.h"
-#include "screen.h"
+#include "frame.h"
 #include "icc.h"
 #include "icon.h"
-#include "style.h"
 #include "prefs.h"
+#include "screen.h"
+#include "style.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -15,8 +16,6 @@
 #include <pragmas/xlib_pragmas.h>
 extern struct Library *XLibBase;
 #endif
-
-extern void redraw(Client *, Window);
 
 Atom ATOMS[NATOMS];
 

--- a/icc.h
+++ b/icc.h
@@ -3,19 +3,6 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
-#include "client.h"
-
-extern void init_atoms(void);
-extern void setsupports(Window, Window);
-extern void sendcmessage(Window, Atom, long);
-extern void getproto(Client *c);
-extern void getwmstate(Client *c);
-extern void setwmstate(Client *c);
-extern void setstringprop(Window, Atom, char *);
-extern void propertychange(Client *, Atom);
-extern long _getprop(Window, Atom, Atom, long, char **);
-extern void getwflags(Client *);
-extern Window get_transient_for(Window);
 
 #define Pdelete 1
 #define Ptakefocus 2
@@ -61,6 +48,21 @@ enum {
 #undef  X
 };
 
+struct _Client;
+
 extern Atom ATOMS[NATOMS];
+
+extern Window get_transient_for(Window);
+extern long _getprop(Window, Atom, Atom, long, char **);
+extern void getproto(struct _Client *c);
+extern void getwflags(struct _Client *);
+extern void getwmstate(struct _Client *c);
+extern void handle_client_message(struct _Client *, XClientMessageEvent *);
+extern void init_atoms(void);
+extern void propertychange(struct _Client *, Atom);
+extern void sendcmessage(Window, Atom, long);
+extern void setstringprop(Window, Atom, char *);
+extern void setsupports(Window, Window);
+extern void setwmstate(struct _Client *c);
 
 #endif

--- a/icon.c
+++ b/icon.c
@@ -7,6 +7,7 @@
 #include "screen.h"
 #include "icon.h"
 #include "client.h"
+#include "diskobject.h"
 #include "prefs.h"
 #include "icc.h"
 #include "style.h"
@@ -21,8 +22,6 @@ extern struct Library *XLibBase;
 extern Display *dpy;
 extern char *progname;
 extern XContext icon_context, client_context, screen_context;
-
-extern void init_iconpalette();
 
 #ifdef USE_FONTSETS
 XFontSet labelfontset;

--- a/icon.h
+++ b/icon.h
@@ -28,18 +28,22 @@ struct IconPixmaps
   struct ColorStore cs, cs2;
 };
 
-extern void redrawicon(Icon *, Window);
-extern void rmicon(Icon *);
+extern void adjusticon(Icon *);
+extern void cleanupicons();
+extern Icon *createappicon(struct module *, Window, char *, Pixmap, Pixmap, Pixmap, int, int);
+extern void createdefaulticons();
 extern void createicon(Client *);
 extern void createiconicon(Icon *i, XWMHints *);
-extern void destroyiconicon(Icon *);
-extern void cleanupicons();
-extern void createdefaulticons();
-extern void adjusticon(Icon *);
-extern void selecticon(Icon *);
+extern void deiconify(Icon *);
+extern void deselect_all_icons(struct _Scrn *);
 extern void deselecticon(Icon *);
+extern void destroyiconicon(Icon *);
 extern void free_icon_pms(struct IconPixmaps *pms);
 extern void iconify(Client *);
-extern void deiconify(Icon *);
+extern void redrawicon(Icon *, Window);
+extern void reparenticon(Icon *, struct _Scrn *, int, int);
+extern void rmicon(Icon *);
+extern void select_all_icons(struct _Scrn *i);
+extern void selecticon(Icon *);
 
 #endif

--- a/launchermodule.c
+++ b/launchermodule.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xresource.h>
 #include "libami.h"
 #include "drawinfo.h"
 

--- a/main.c
+++ b/main.c
@@ -36,97 +36,38 @@
 #include <locale.h>
 #endif
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
-#include "prefs.h"
-#include "module.h"
+#include "drawinfo.h"
+#include "events.h"
+#include "frame.h"
 #include "icc.h"
+#include "icon.h"
 #include "libami.h"
+#include "menu.h"
+#include "module.h"
+#include "prefs.h"
+#include "rc.h"
+#include "screen.h"
 
-#ifdef AMIGAOS
-#include <pragmas/xlib_pragmas.h>
-extern struct Library *XLibBase;
-
-struct timeval {
-  long tv_sec;
-  long tv_usec;
-};
-
-#define fd_set XTransFdset
-#undef FD_ZERO
-#undef FD_SET
-#define FD_ZERO XTransFdZero
-#define FD_SET XTransFdSet
-#define select XTransSelect
-#endif
 
 #define HYSTERESIS 5
 
-typedef struct _DragIcon {
-  Icon *icon;
-  Window w;
-  Pixmap pm;
-  int x, y;
-} DragIcon;
-
 Display *dpy = NULL;
-Client *activeclient=NULL, *clickclient=NULL;
-Window clickwindow=None;
-Scrn *menuactive=NULL;
+Client *activeclient=NULL;
 Bool shape_extn=False;
 char *x_server=NULL;
-char *free_screentitle=NULL;
 XContext client_context, screen_context, icon_context, menu_context, vroot_context;
 char *progname;
 Cursor wm_curs;
 
 static int signalled=0, forcemoving=0;
-static Time last_icon_click=0, last_double=0;
-static Client *doubleclient=NULL;
 static int initting=0;
 static int ignore_badwindow=0;
-static int dblClickTime=1500;
-static fd_set master_fd_set;
-static int max_fd=0;
 static Window *checkwins;
 static int shape_event_base, shape_error_base;
 static int server_grabs=0;
-static unsigned int meta_mask, switch_mask;
 
 static char **main_argv;
-
-extern Scrn *mbdclick, *mbdscr;
-
-extern void reparent(Client *);
-extern void redraw(Client *, Window);
-extern void redrawclient(Client *);
-extern void redrawmenubar(Scrn *, Window);
-extern void resizeclientwindow(Client *c, int, int);
-extern void gadgetclicked(Client *c, Window w, XEvent *e);
-extern void gadgetunclicked(Client *c, XEvent *e);
-extern void gadgetaborted(Client *c);
-extern void clickenter(void);
-extern void clickleave(void);
-extern void menu_on(void);
-extern void menu_off(void);
-extern void menubar_enter(Window);
-extern void menubar_leave(Window);
-extern void *getitembyhotkey(KeySym);
-extern void menuaction(void *);
-extern Scrn *getscreenbyroot(Window);
-extern void assimilate(Window, int, int);
-extern void deselect_all_icons(Scrn *);
-extern void reparenticon(Icon *, Scrn *, int, int);
-extern void handle_client_message(Client *, XClientMessageEvent *);
-extern void handle_module_input(fd_set *);
-extern int dispatch_event_to_broker(XEvent *, unsigned long, struct module *);
-extern void reshape_frame(Client *c);
-extern void read_rc_file(char *filename, int manage_all);
-extern void init_modules();
-extern void flushmodules();
-extern void raiselowerclient(Client *, int);
 
 #ifndef AMIGAOS
 void restart_amiwm()
@@ -139,7 +80,7 @@ void restart_amiwm()
 }
 #endif
 
-int handler(Display *d, XErrorEvent *e)
+static int handler(Display *d, XErrorEvent *e)
 {
   if (initting && (e->request_code == X_ChangeWindowAttributes) &&
       (e->error_code == BadAccess)) {
@@ -170,150 +111,6 @@ int handler(Display *d, XErrorEvent *e)
   return 0;
 }
 
-static struct coevent {
-  struct coevent *next;
-  struct timeval when;
-  void (*what)(void *);
-  void *with;
-} *eventlist=NULL;
-
-#define FIXUPTV(tv) { \
-    while((tv).tv_usec<0) { (tv).tv_usec+=1000000; (tv).tv_sec--; } \
-    while((tv).tv_usec>=1000000) { (tv).tv_usec-=1000000; (tv).tv_sec++; } \
-}
-
-static void remove_call_out(void (*what)(void *), void *with)
-{
-  struct coevent *ee, **e=&eventlist;
-
-  while(*e && ((*e)->what != what || (*e)->with != with))
-    e=&(*e)->next;
-  if((ee=*e)) {
-    *e=(*e)->next;
-    free(ee);
-  }
-}
-
-#ifdef BSD_STYLE_GETTIMEOFDAY
-#define GETTIMEOFDAY(tp) gettimeofday(tp, NULL)
-#else
-#define GETTIMEOFDAY(tp) gettimeofday(tp)
-#endif
-
-static void call_out(int howlong_s, int howlong_u, void (*what)(void *), void *with)
-{
-  struct coevent *ce=malloc(sizeof(struct coevent));
-  if(ce) {
-    struct coevent **e=&eventlist;
-    GETTIMEOFDAY(&ce->when);
-    ce->when.tv_sec+=howlong_s;
-    ce->when.tv_usec+=howlong_u;
-    FIXUPTV(ce->when);
-    ce->what=what;
-    ce->with=with;
-    while(*e && ((*e)->when.tv_sec<ce->when.tv_sec ||
-		 ((*e)->when.tv_sec==ce->when.tv_sec &&
-		  (*e)->when.tv_usec<=ce->when.tv_usec)))
-      e=&(*e)->next;
-    ce->next=*e;
-    *e=ce;
-  }
-}
-
-static void call_call_out()
-{
-  struct timeval now;
-  struct coevent *e;
-  GETTIMEOFDAY(&now);
-  FIXUPTV(now);
-  while((e=eventlist) && (e->when.tv_sec<now.tv_sec ||
-			  (e->when.tv_sec==now.tv_sec &&
-			   e->when.tv_usec<=now.tv_usec))) {
-    eventlist=e->next;
-    (e->what)(e->with);
-    free(e);
-  }
-}
-
-static void fill_in_call_out(struct timeval *tv)
-{
-  GETTIMEOFDAY(tv);
-  tv->tv_sec=eventlist->when.tv_sec-tv->tv_sec;
-  tv->tv_usec=eventlist->when.tv_usec-tv->tv_usec;
-  FIXUPTV(*tv);
-  if(tv->tv_sec<0)
-    tv->tv_sec = tv->tv_usec = 0;
-}
-
-void add_fd_to_set(int fd)
-{
-  FD_SET(fd, &master_fd_set);
-  if(fd>=max_fd)
-    max_fd=fd+1;
-}
-
-void remove_fd_from_set(int fd)
-{
-  FD_CLR(fd, &master_fd_set);
-}
-
-static void lookup_keysyms(Display *dpy, unsigned int *meta_mask,
-    unsigned int *switch_mask)
-{
-  int i,j,k,maxsym,mincode,maxcode;
-  XModifierKeymap *map=XGetModifierMapping(dpy);
-  KeySym *kp, *kmap;
-  unsigned int alt_mask = 0;
-  *meta_mask=0, *switch_mask=0;
-  XDisplayKeycodes(dpy, &mincode, &maxcode);
-  kmap=XGetKeyboardMapping(dpy, mincode, maxcode-mincode+1, &maxsym);
-  for(i=3; i<8; i++)
-    for(j=0; j<map->max_keypermod; j++)
-      if(map->modifiermap[i*map->max_keypermod+j] >= mincode)
-	for(kp=kmap+(map->modifiermap[i*map->max_keypermod+j]-mincode)*maxsym,
-	      k=0; k<maxsym; k++)
-	  switch(*kp++) {
-	  case XK_Meta_L:
-	  case XK_Meta_R:
-	    *meta_mask|=1<<i;
-	    break;
-	  case XK_Mode_switch:
-	    *switch_mask|=1<<i;
-	    break;
-	  case XK_Alt_L:
-	  case XK_Alt_R:
-	    alt_mask|=1<<i;
-	    break;
-	  }
-  XFree(kmap);
-  XFreeModifiermap(map);
-  if(*meta_mask == 0)
-    *meta_mask = (alt_mask? alt_mask :
-		 (*switch_mask? *switch_mask : Mod1Mask));
-}
-
-
-static void restorescreentitle(Scrn *s)
-{
-  (scr=s)->title=s->deftitle;
-  XClearWindow(dpy, s->menubar);
-  redrawmenubar(s, s->menubar);
-  if(free_screentitle) {
-    free(free_screentitle);
-    free_screentitle=NULL;
-  }
-}
-
-void wberror(Scrn *s, char *message)
-{
-  remove_call_out((void(*)(void *))restorescreentitle, s);
-  (scr=s)->title=message;
-  XClearWindow(dpy, s->menubar);
-  redrawmenubar(s, s->menubar);
-  XBell(dpy, 100);
-  call_out(2, 0, (void(*)(void *))restorescreentitle, s);
-}
-
 void setfocus(Window w)
 {
   if(w == None && prefs.focus != FOC_CLICKTOTYPE)
@@ -336,102 +133,6 @@ static void ungrab_server()
     if(prefs.titlebarclock) {
       remove_call_out(update_clock, NULL);
       update_clock(NULL);
-    }
-  }
-}
-
-static void compress_motion(XEvent *event)
-{
-  if (event->type != MotionNotify)
-    return;
-  while (XCheckTypedWindowEvent(dpy, event->xmotion.window, MotionNotify, event))
-    ;
-}
-
-static Bool grab_for_motion(Window w, Window confine, Cursor curs, Time time, int x_root, int y_root)
-{
-  /*
-   * To avoid misclicks, only grab for move/resize/etc, if the user has
-   * moved the pointer by a given threshold.
-   */
-  static const int THRESHOLD = 5;
-  int status;
-
-  XSync(dpy, False);
-  status = XGrabPointer(dpy, w, False,
-                        ButtonPressMask|ButtonReleaseMask|Button1MotionMask,
-                        GrabModeAsync, GrabModeAsync, confine, None, time);
-  if (status == AlreadyGrabbed || status == GrabSuccess) {
-    for (;;) {
-      XEvent event;
-      int dx, dy;
-
-      XMaskEvent(dpy, ButtonPressMask|ButtonReleaseMask|Button1MotionMask, &event);
-      XPutBackEvent(dpy, &event);
-      if (event.type != MotionNotify)
-        break;
-      compress_motion(&event);
-      dx = x_root - event.xmotion.x_root;
-      dy = y_root - event.xmotion.y_root;
-      if (dx*dx + dy*dy > THRESHOLD*THRESHOLD) /* Pythagoras! */
-        return True;
-    }
-  }
-  XUngrabPointer(dpy, CurrentTime);
-  return False;
-}
-
-static void get_drag_event(XEvent *event)
-{
-  static const unsigned int DRAG_MASK = ButtonPressMask|ButtonReleaseMask|Button1MotionMask;
-
-  for (;;) {
-    fd_set rfds = master_fd_set;
-    struct timeval t = {
-      .tv_sec = 0,
-      .tv_usec = 0,
-    };
-
-    while (XCheckMaskEvent(dpy, ExposureMask|DRAG_MASK, event)) {
-      Client *c = NULL;
-      Icon *i = NULL;
-      Scrn *s = NULL;
-
-      if (event->type == MotionNotify)
-        compress_motion(event);
-      if (event->type != Expose)
-        return;
-      if (event->xexpose.count)
-        continue;
-      else if (!XFindContext(dpy, event->xexpose.window, client_context, (XPointer*)&c))
-        redraw(c, event->xexpose.window);
-      else if (!XFindContext(dpy, event->xexpose.window, icon_context, (XPointer*)&i))
-        redrawicon(i, event->xexpose.window);
-      else if (!XFindContext(dpy, event->xexpose.window, screen_context, (XPointer*)&s))
-        redrawmenubar(s, event->xexpose.window);
-      continue;
-    }
-
-    if (select(max_fd, &rfds, NULL, NULL, &t) > 0) {
-      handle_module_input(&rfds);
-      if(FD_ISSET(ConnectionNumber(dpy), &rfds))
-        XFlush(dpy);
-      continue;
-    }
-    XFlush(dpy);
-    rfds = master_fd_set;
-    if(eventlist)
-      fill_in_call_out(&t);
-    if(select(max_fd, &rfds, NULL, NULL, (eventlist? &t:NULL))<0) {
-      if (errno != EINTR) {
-        perror("select");
-        break;
-      }
-    } else {
-      call_call_out();
-      handle_module_input(&rfds);
-      if(FD_ISSET(ConnectionNumber(dpy), &rfds))
-        XFlush(dpy);
     }
   }
 }
@@ -497,7 +198,7 @@ static void drag_bounding(Scrn *s, Time time, int x_root, int y_root, int x, int
   call_out(0, 0, move_dashes, &bounding);
   for (;;) {
     XEvent event;
-    get_drag_event(&event);
+    event = get_drag_event();
     draw_bounding(&bounding);
     if (event.type == ButtonRelease && event.xbutton.button == Button1) {
       remove_call_out(move_dashes, &bounding);
@@ -554,7 +255,7 @@ static void drag_move(Client *c, Time time, int x_root, int y_root)
   }
   for (;;) {
     XEvent event;
-    get_drag_event(&event);
+    event = get_drag_event();
     if(!prefs.opaquemove) {
       XDrawRectangle(dpy, c->scr->back, c->scr->rubbergc,
                      x, y, c->pwidth-1, c->pheight-1);
@@ -610,7 +311,7 @@ static void drag_screen(Scrn *s, Time time, int x_root, int y_root)
     return;
   for (;;) {
     XEvent event;
-    get_drag_event(&event);
+    event = get_drag_event();
     if (event.type == ButtonRelease && event.xbutton.button == Button1) {
       s->y = y;
       break;
@@ -638,7 +339,12 @@ static void drag_screen(Scrn *s, Time time, int x_root, int y_root)
 static void drag_icon(Scrn *s, Time time, int x_root, int y_root)
 {
   int nicons = 0;
-  DragIcon *dragging = NULL;
+  struct {
+    Icon *icon;
+    Window w;
+    Pixmap pm;
+    int x, y;
+  } *dragging = NULL;
   Icon *i;
 
   for (i = s->firstselected; i != NULL; i = i->nextselected)
@@ -729,7 +435,7 @@ static void drag_icon(Scrn *s, Time time, int x_root, int y_root)
 
   for (;;) {
     XEvent event;
-    get_drag_event(&event);
+    event = get_drag_event();
     if (event.type == ButtonRelease && event.xbutton.button == Button1) {
       Scrn *s = get_front_scr();
       int wx, wy;
@@ -830,7 +536,7 @@ static void drag_resize(Client *c, Time time, int x_root, int y_root)
     XDrawRectangle(dpy, c->scr->back, c->scr->rubbergc, c->x, c->y, w-1, h-1);
   for (;;) {
     XEvent event;
-    get_drag_event(&event);
+    event = get_drag_event();
     if(!prefs.opaqueresize)
       XDrawRectangle(dpy, c->scr->back, c->scr->rubbergc, c->x, c->y, w-1, h-1);
     if (event.type == ButtonRelease && event.xbutton.button == Button1) {
@@ -890,6 +596,15 @@ static void do_icon_double_click(Scrn *scr)
   }
 }
 
+static Bool is_double_click(XButtonEvent *prev, XButtonEvent *curr)
+{
+  static const int DOUBLE_CLICK_TIME = 500;
+
+  return curr->time - prev->time < DOUBLE_CLICK_TIME &&
+         curr->button == prev->button &&
+         curr->window == prev->window;
+}
+
 static void abortfocus()
 {
   if(activeclient) {
@@ -913,39 +628,6 @@ static RETSIGTYPE sighandler(int sig)
 static void instcmap(Colormap c)
 {
   XInstallColormap(dpy, (c == None) ? scr->cmap : c);
-}
-
-void internal_broker(XEvent *e)
-{
-
-  /*
-   * XXX this is one of the things that the code in module.c
-   * is abusing to overload display with some numeric
-   * values.  Surely there's a better way to do this?
-   */
-  uintptr_t event_loc=(uintptr_t)e->xany.display;
-
-  e->xany.display=dpy;
-  if(event_loc==1) {
-    XSendEvent(dpy, e->xany.window, False, 0, e);
-  } else switch(e->type) {
-  case MappingNotify:
-    if(e->xmapping.request==MappingKeyboard ||
-       e->xmapping.request==MappingModifier)
-      XRefreshKeyboardMapping(&e->xmapping);
-    lookup_keysyms(dpy, &meta_mask, &switch_mask);
-    break;
-  case KeyPress:
-    if(e->xkey.state & meta_mask) {
-      KeySym ks=XLookupKeysym(&e->xkey,
-			      ((e->xkey.state & ShiftMask)?1:0)+
-			      ((e->xkey.state & switch_mask)?2:0));
-      void *item;
-      if((item=getitembyhotkey(ks)))
-	menuaction(item);
-    }
-    break;
-  }
 }
 
 static void update_clock(void *dontcare)
@@ -995,6 +677,7 @@ int main(int argc, char *argv[])
   int x_fd, sc;
   static Argtype array[3];
   struct RDArgs *ra;
+  XButtonEvent last_press = {0};
 
 #ifdef USE_FONTSETS
   setlocale(LC_CTYPE, "");
@@ -1076,8 +759,6 @@ int main(int argc, char *argv[])
     fprintf(stderr, "%s: child cannot disinherit TCP fd\n", progname);
 #endif
 
-  lookup_keysyms(dpy, &meta_mask, &switch_mask);
-
   checkwins = calloc(ScreenCount(dpy), sizeof(*checkwins));
   for(sc=0; sc<ScreenCount(dpy); sc++) {
     if(sc==DefaultScreen(dpy) || prefs.manage_all) {
@@ -1115,7 +796,7 @@ int main(int argc, char *argv[])
     while((!signalled) && QLength(dpy)>0) {
       Client *c; Icon *i;
 
-      XNextEvent(dpy, &event);
+      event = get_next_event();
       if(!XFindContext(dpy, event.xany.window, client_context,
 		       (XPointer*)&c)) {
 	scr=c->scr;
@@ -1130,16 +811,6 @@ int main(int argc, char *argv[])
       else
 	scr=i->scr;
       switch(event.type) {
-      case Expose:
-	if(!event.xexpose.count) {
-	  if(c)
-	    redraw(c, event.xexpose.window);
-	  else if(i)
-	    redrawicon(i, event.xexpose.window);
-	  else if(scr)
-	    redrawmenubar(scr, event.xexpose.window);
-	}
-	break;
       case CreateNotify:
 
 	if(!XFindContext(dpy, event.xcreatewindow.window, client_context,
@@ -1188,8 +859,6 @@ int main(int argc, char *argv[])
 	    XGrabButton(dpy, Button1, AnyModifier, c->parent, True,
 			ButtonPressMask, GrabModeSync, GrabModeAsync,
 			None, wm_curs);
-	  if(!menuactive)
-	    setfocus(None);
 	}
 	if(c && (event.xunmap.window==c->window)) {
 	  if((!c->reparenting) && c->parent != c->scr->root) {
@@ -1246,7 +915,7 @@ int main(int argc, char *argv[])
       case GravityNotify:
       case NoExpose:
       case GraphicsExpose:
-	break;
+        break;
       case ClientMessage:
 	if(c)
 	  handle_client_message(c, &event.xclient);
@@ -1365,12 +1034,7 @@ int main(int argc, char *argv[])
 	}
 	break;
       case EnterNotify:
-	if(menuactive) {
-	  scr=menuactive;
-	  menubar_enter(event.xcrossing.window);
-	} else if(clickwindow && event.xcrossing.window == clickwindow)
-	  clickenter();
-	else if(c) {
+	if(c) {
 	  if((!c->active) && (c->state==NormalState) &&
 	     prefs.focus!=FOC_CLICKTOTYPE) {
 	    if(activeclient) {
@@ -1389,17 +1053,10 @@ int main(int argc, char *argv[])
 	}
 	break;
       case LeaveNotify:
-	if(menuactive) {
-	  scr=menuactive;
-	  menubar_leave(event.xcrossing.window);
-	} else if(clickwindow && event.xcrossing.window == clickwindow)
-	  clickleave();
-	else if(c) {
+	if(c) {
 	  if(c->active && event.xcrossing.window==c->parent &&
 	     event.xcrossing.detail!=NotifyInferior &&
 	     prefs.focus == FOC_FOLLOWMOUSE) {
-	    if(!menuactive)
-	      setfocus(None);
 	    c->active=False;
 	    activeclient = NULL;
 	    instcmap(None);
@@ -1411,7 +1068,7 @@ int main(int argc, char *argv[])
 	}
 	break;
       case ButtonPress:
-	if(clickwindow==None && event.xbutton.button==Button1 && !menuactive) {
+	if(event.xbutton.button==Button1) {
 	  if(c) {
 	    if((!c->active) && prefs.focus==FOC_CLICKTOTYPE &&
 	       (c->state==NormalState)) {
@@ -1432,12 +1089,8 @@ int main(int argc, char *argv[])
 	    }
 	    if(event.xbutton.window!=c->depth &&
 	       event.xbutton.window!=c->window) {
-	      if(c==doubleclient && (event.xbutton.time-last_double)<
-		 dblClickTime) {
+	      if (is_double_click(&last_press, &event.xbutton)) {
 		XRaiseWindow(dpy, c->parent);
-	      } else {
-		doubleclient=c;
-		last_double=event.xbutton.time;
 	      }
 	    }
 	    if(event.xbutton.window==c->drag) {
@@ -1449,23 +1102,27 @@ int main(int argc, char *argv[])
 	    else if(event.xbutton.window==c->window ||
 		    event.xbutton.window==c->parent)
 	      ;
-	    else
-	      gadgetclicked(c, event.xbutton.window, &event);
+	    else if (event.xbutton.window == c->close) {
+              click_close(c, event.xbutton.time);
+	    } else if (event.xbutton.window == c->iconify) {
+              click_iconify(c, event.xbutton.time);
+	    } else if (event.xbutton.window == c->depth) {
+              click_depth(c, event.xbutton.time);
+	    } else if (event.xbutton.window == c->zoom) {
+              click_zoom(c, event.xbutton.time);
+            }
 	  } else if(i && event.xbutton.window==i->window) {
 	    abortfocus();
-	    if(i->selected && (event.xbutton.time-last_icon_click)<dblClickTime) {
+	    if(i->selected && is_double_click(&last_press, &event.xbutton)) {
 	      do_icon_double_click(i->scr);
 	    } else {
 	      if(!(event.xbutton.state & ShiftMask))
 		deselect_all_icons(i->scr);
-	      last_icon_click=event.xbutton.time;
 	      selecticon(i);
               drag_icon(i->scr, event.xbutton.time, event.xbutton.x_root, event.xbutton.y_root);
 	    }
 	  } else if(scr&&event.xbutton.window==scr->menubardepth) {
-	    clickwindow=scr->menubardepth;
-	    mbdclick=mbdscr=scr;
-	    redrawmenubar(scr, scr->menubardepth);
+	    click_screendepth(scr, event.xbutton.time);
 	  } else if(scr&&event.xbutton.window==scr->menubar &&
 		    scr->back!=scr->root) {
 	    drag_screen(scr, event.xbutton.time, event.xbutton.x_root, event.xbutton.y_root);
@@ -1476,54 +1133,19 @@ int main(int argc, char *argv[])
                           event.xbutton.x, event.xbutton.y);
 	  } else ;
 	} else if(event.xbutton.button==3) {
-	  if(scr&&(scr==mbdscr)&&clickwindow==scr->menubardepth) {
-	    mbdclick=NULL;
-	    clickwindow=None;
-	    redrawmenubar(scr, scr->menubardepth);
-	  } else if(clickclient) {
-	    gadgetaborted(clickclient);
-	  } else if(scr&&!menuactive) {
-	    menu_on();
-	    menuactive=scr;
+	  if(c == NULL && scr != NULL) {
+	    drag_menu(scr, event.xbutton.time);
 	  }
 	}
-	if(prefs.focus == FOC_CLICKTOTYPE && !menuactive) {
+	if(prefs.focus == FOC_CLICKTOTYPE) {
 	  XSync(dpy,0);
 	  XAllowEvents(dpy,ReplayPointer,CurrentTime);
 	  XSync(dpy,0);
 	}
+        last_press = event.xbutton;
 	break;
       case ButtonRelease:
-	if(event.xbutton.button==Button1) {
-	  if(clickclient)
-	    gadgetunclicked(clickclient, &event);
-	  else if((scr=mbdscr)&& clickwindow==scr->menubardepth) {
-	    if(mbdclick) {
-	      mbdclick=NULL;
-	      redrawmenubar(scr, scr->menubardepth);
-	      screentoback();
-	    }
-	    clickwindow=None;
-	  }
-	} else if(event.xbutton.button==Button3 && (scr=menuactive)) {
-	  menu_off();
-	  menuactive=NULL;
-	}
-	break;
-      case MotionNotify:
-	break;
-      case KeyPress:
-	if(!dispatch_event_to_broker(&event, KeyPressMask, modules))
-	  internal_broker(&event);
-	break;
-      case KeyRelease:
-	if(!dispatch_event_to_broker(&event, KeyPressMask, modules))
-	  internal_broker(&event);
-	break;
-      case MappingNotify:
-	if(!dispatch_event_to_broker(&event, 0, modules))
-	  internal_broker(&event);
-	break;
+        break;
       case PropertyNotify:
 	if(event.xproperty.atom != None && c &&
 	   event.xproperty.window==c->window &&

--- a/menu.c
+++ b/menu.c
@@ -9,8 +9,11 @@
 
 #include "alloc.h"
 #include "drawinfo.h"
+#include "events.h"
 #include "prefs.h"
 #include "screen.h"
+#include "menu.h"
+#include "module.h"
 #include "client.h"
 #include "icon.h"
 #include "version.h"
@@ -44,13 +47,10 @@ extern Cursor wm_curs;
 extern XContext screen_context, client_context;
 extern Client *activeclient;
 
-extern void select_all_icons(Scrn *i);
-extern void mod_menuselect(struct module *, int, int, int);
 extern void setfocus(Window);
-extern void flushmodules();
 extern void wberror(Scrn *, char *);
 
-Scrn *mbdclick=NULL, *mbdscr=NULL;
+Scrn *mbdclick=NULL;
 
 static struct ToolItem {
   struct ToolItem *next;
@@ -594,7 +594,7 @@ void redrawmenubar(Scrn *scr, Window w)
     }
   } else if(w==scr->menubardepth) {
     /* Menubar depth widget */
-    if(!mbdclick) {
+    if(mbdclick != scr) {
       XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[SHADOWPEN]);
       XDrawRectangle(dpy, w, scr->menubargc, 4, scr->h2, 10, scr->h6-scr->h2);
     }
@@ -602,12 +602,12 @@ void redrawmenubar(Scrn *scr, Window w)
     XFillRectangle(dpy, w, scr->menubargc, 8, scr->h4, 10, scr->h8-scr->h4);
     XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[SHADOWPEN]);
     XDrawRectangle(dpy, w, scr->menubargc, 8, scr->h4, 10, scr->h8-scr->h4);
-    if(mbdclick)
+    if(mbdclick == scr)
       XDrawRectangle(dpy, w, scr->menubargc, 4, scr->h2, 10, scr->h6-scr->h2);
-    XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[mbdclick?SHADOWPEN:SHINEPEN]);
+    XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[mbdclick==scr?SHADOWPEN:SHINEPEN]);
     XDrawLine(dpy, w, scr->menubargc, 0, 0, 22, 0);
     XDrawLine(dpy, w, scr->menubargc, 0, 0, 0, scr->bh-2);
-    XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[mbdclick?SHINEPEN:SHADOWPEN]);
+    XSetForeground(dpy, scr->menubargc, scr->dri.dri_Pens[mbdclick==scr?SHINEPEN:SHADOWPEN]);
     XDrawLine(dpy, w, scr->menubargc, 0, scr->bh-1, 22, scr->bh-1);
     XDrawLine(dpy, w, scr->menubargc, 22, 0, 22, scr->bh-1);
   } else {
@@ -642,6 +642,8 @@ void redrawmenubar(Scrn *scr, Window w)
 
 static void leave_item(struct Item *i, Window w)
 {
+  if (i == NULL)
+    return;
   if(i==activesubitem)
     activesubitem=NULL;
   if(i==activeitem) {
@@ -708,7 +710,7 @@ static void enter_menu(struct Menu *m, Window w)
   }
 }
 
-void menubar_enter(Window w)
+static void menubar_enter(Window w)
 {
   struct Menu *m;
   struct Item *i;
@@ -732,30 +734,12 @@ void menubar_enter(Window w)
       }
 }
 
-void menubar_leave(Window w)
+static void menubar_leave(Window w)
 {
   if(activesubitem && activesubitem->win==w)
     leave_item(activesubitem, w);
   if(activeitem && activeitem->win==w)
     leave_item(activeitem, w);
-}
-
-void menu_on()
-{
-  Window r, c;
-  int rx, ry, x, y;
-  unsigned int m;
-
-  if(scr->menubarparent) {
-    XMapRaised(dpy, scr->menubarparent);
-    XRaiseWindow(dpy, scr->menubar);
-    XGrabPointer(dpy, scr->back, True, ButtonPressMask|ButtonReleaseMask|
-		EnterWindowMask|LeaveWindowMask, GrabModeAsync, GrabModeAsync,
-		scr->back, wm_curs, CurrentTime);
-    XSetInputFocus(dpy, scr->menubar, RevertToParent, CurrentTime);
-    if(XQueryPointer(dpy, scr->menubarparent, &r, &c, &rx, &ry, &x, &y, &m))
-      menubar_enter(c);
-  }
 }
 
 void menuaction(struct Item *i, struct Item *si)
@@ -887,57 +871,6 @@ void menuaction(struct Item *i, struct Item *si)
   }
 }
 
-void menu_off()
-{
-  struct Menu *oa;
-  struct Item *oi, *osi;
-
-  if(scr->menubarparent) {
-    Window r,p,*children;
-    unsigned int nchildren;
-    XUngrabPointer(dpy, CurrentTime);
-    setfocus((activeclient && activeclient->state==NormalState?
-	      activeclient->window:None));
-    XUnmapWindow(dpy, scr->menubarparent);
-    if(XQueryTree(dpy, scr->back, &r, &p, &children, &nchildren)) {
-      int n;
-      Client *c2;
-      for(n=0; n<nchildren; n++)
-	if((!XFindContext(dpy, children[n], client_context, (XPointer*)&c2)) &&
-	   children[n]==c2->parent)
-	  break;
-      if(n<nchildren) {
-	Window ws[2];
-	ws[0]=children[n];
-	ws[1]=scr->menubar;
-	XRestackWindows(dpy, ws, 2);
-      }
-      if(children) XFree(children);
-    }
-  }
-  if((osi=activesubitem))
-    leave_item(osi, osi->win);
-  if((oi=activeitem))
-    leave_item(oi, oi->win);
-  if((oa=activesubmenu)) {
-    activesubmenu=NULL;
-    if(oa->parent)
-      XUnmapWindow(dpy, oa->parent);
-  }
-  if((oa=activemenu)) {
-    activemenu=NULL;
-    if(oa->parent)
-      XUnmapWindow(dpy, oa->parent);
-    XSetWindowBackground(dpy, oa->win, scr->dri.dri_Pens[BARBLOCKPEN]);
-    XClearWindow(dpy, oa->win);
-    redraw_menu(oa, oa->win);
-  }
-  if(oi) {
-    XSync(dpy, False);
-    menuaction(oi, osi);
-  }
-}
-
 struct Item *getitembyhotkey(KeySym key)
 {
   struct Menu *m;
@@ -1022,4 +955,62 @@ struct Item *own_items(struct module *m, Scrn *s,
   if(endlink)
     endlink->next = c;
   return chain;
+}
+
+void drag_menu(Scrn *s, Time time)
+{
+  Window w;
+  struct Item *saved_item = NULL;
+  struct Item *saved_subitem = NULL;
+
+  if (s->menubarparent == None)
+    return;
+  XMapRaised(dpy, s->menubarparent);
+  XRaiseWindow(dpy, s->menubar);
+  XGrabPointer(dpy, s->back, True, ButtonPressMask|ButtonReleaseMask|
+              EnterWindowMask|LeaveWindowMask, GrabModeAsync, GrabModeAsync,
+              s->back, wm_curs, time);
+  XGrabKeyboard(dpy, s->menubar, True, GrabModeAsync, GrabModeAsync, time);
+  if(XQueryPointer(dpy, s->menubarparent, &(Window){0}, &w,
+                   &(int){0}, &(int){0}, &(int){0}, &(int){0}, &(unsigned){0}))
+    menubar_enter(w);
+  for (;;) {
+    XEvent event;
+
+    event = get_drag_event();
+    if (event.type == ButtonRelease && event.xbutton.button == Button3) {
+      XUngrabPointer(dpy, event.xbutton.time);
+      XUngrabKeyboard(dpy, event.xbutton.time);
+      break;
+    } else if (event.type == EnterNotify) {
+      menubar_enter(event.xcrossing.window);
+    } else if (event.type == LeaveNotify) {
+      menubar_leave(event.xcrossing.window);
+    }
+  }
+  XUnmapWindow(dpy, s->menubarparent);
+  saved_item = activeitem;
+  saved_subitem = activesubitem;
+  if(activesubitem != NULL)
+    leave_item(activesubitem, activesubitem->win);
+  if(activeitem != NULL)
+    leave_item(activeitem, activeitem->win);
+  if(activesubmenu != NULL) {
+    if(activesubmenu->parent)
+      XUnmapWindow(dpy, activesubmenu->parent);
+    activesubmenu=NULL;
+  }
+  if(activemenu != NULL) {
+    struct Menu *saved_menu = activemenu;
+    activemenu=NULL;
+    if(saved_menu->parent)
+      XUnmapWindow(dpy, saved_menu->parent);
+    XSetWindowBackground(dpy, saved_menu->win, s->dri.dri_Pens[BARBLOCKPEN]);
+    XClearWindow(dpy, saved_menu->win);
+    redraw_menu(saved_menu, saved_menu->win);
+  }
+  if(saved_item != NULL) {
+    XSync(dpy, False);
+    menuaction(saved_item, saved_subitem);
+  }
 }

--- a/menu.h
+++ b/menu.h
@@ -1,0 +1,12 @@
+struct Item;
+struct _Scrn;
+struct module;
+
+extern void drag_menu(struct _Scrn *, Time time);
+extern void menuaction(struct Item *, struct Item *);
+extern void redrawmenubar(struct _Scrn *, Window);
+extern struct Item *getitembyhotkey(KeySym key);
+
+extern void disown_item_chain(struct module *m, struct Item *i);
+extern struct Item *own_items(struct module *m, struct _Scrn *s,
+		       int menu, int item, int sub, struct Item *c);

--- a/module.c
+++ b/module.c
@@ -23,12 +23,15 @@
 #include <X11/Xlib.h>
 
 #include "alloc.h"
-#include "drawinfo.h"
-#include "screen.h"
-#include "prefs.h"
-#include "module.h"
 #include "client.h"
+#include "drawinfo.h"
+#include "events.h"
+#include "frame.h"
 #include "icon.h"
+#include "menu.h"
+#include "module.h"
+#include "prefs.h"
+#include "screen.h"
 #include "version.h"
 
 extern XContext client_context, icon_context, screen_context;
@@ -36,22 +39,11 @@ extern XContext client_context, icon_context, screen_context;
 extern FILE *rcfile;
 extern Display *dpy;
 
-extern void add_fd_to_set(int);
-extern void remove_fd_from_set(int);
-
-extern void raiselowerclient(Client *, int);
-extern void wberror(Scrn *, char *);
-
-extern Icon *createappicon(struct module *, Window, char *,
-			   Pixmap, Pixmap, Pixmap, int, int);
-
-extern struct Item *own_items(struct module *, Scrn *,
-			       int, int, int, struct Item *);
-extern void disown_item_chain(struct module *, struct Item *);
-
+char *free_screentitle=NULL;
 struct module *modules = NULL;
-
 struct mcmd_keygrab *keygrabs = NULL;
+
+static unsigned int meta_mask, switch_mask;
 
 static struct mcmd_keygrab *find_keygrab(int keycode, unsigned int modifiers)
 {
@@ -165,6 +157,41 @@ void reap_children(int sig)
     signal(sig, reap_children);
 }
 
+static void lookup_keysyms(Display *dpy, unsigned int *meta_mask,
+    unsigned int *switch_mask)
+{
+  int i,j,k,maxsym,mincode,maxcode;
+  XModifierKeymap *map=XGetModifierMapping(dpy);
+  KeySym *kp, *kmap;
+  unsigned int alt_mask = 0;
+  *meta_mask=0, *switch_mask=0;
+  XDisplayKeycodes(dpy, &mincode, &maxcode);
+  kmap=XGetKeyboardMapping(dpy, mincode, maxcode-mincode+1, &maxsym);
+  for(i=3; i<8; i++)
+    for(j=0; j<map->max_keypermod; j++)
+      if(map->modifiermap[i*map->max_keypermod+j] >= mincode)
+	for(kp=kmap+(map->modifiermap[i*map->max_keypermod+j]-mincode)*maxsym,
+	      k=0; k<maxsym; k++)
+	  switch(*kp++) {
+	  case XK_Meta_L:
+	  case XK_Meta_R:
+	    *meta_mask|=1<<i;
+	    break;
+	  case XK_Mode_switch:
+	    *switch_mask|=1<<i;
+	    break;
+	  case XK_Alt_L:
+	  case XK_Alt_R:
+	    alt_mask|=1<<i;
+	    break;
+	  }
+  XFree(kmap);
+  XFreeModifiermap(map);
+  if(*meta_mask == 0)
+    *meta_mask = (alt_mask? alt_mask :
+		 (*switch_mask? *switch_mask : Mod1Mask));
+}
+
 void init_modules()
 {
   modules = NULL;
@@ -175,6 +202,7 @@ void init_modules()
   signal(SIGCLD, reap_children);
 #endif
 #endif
+  lookup_keysyms(dpy, &meta_mask, &switch_mask);
 }
 
 void create_module(Scrn *screen, char *module_name, char *module_arg)
@@ -316,6 +344,39 @@ int dispatch_event_to_broker(XEvent *e, unsigned long mask, struct module *m)
   return 0;
 }
 
+void internal_broker(XEvent *e)
+{
+
+  /*
+   * XXX this is one of the things that the code in module.c
+   * is abusing to overload display with some numeric
+   * values.  Surely there's a better way to do this?
+   */
+  uintptr_t event_loc=(uintptr_t)e->xany.display;
+
+  e->xany.display=dpy;
+  if(event_loc==1) {
+    XSendEvent(dpy, e->xany.window, False, 0, e);
+  } else switch(e->type) {
+  case MappingNotify:
+    if(e->xmapping.request==MappingKeyboard ||
+       e->xmapping.request==MappingModifier)
+      XRefreshKeyboardMapping(&e->xmapping);
+    lookup_keysyms(dpy, &meta_mask, &switch_mask);
+    break;
+  case KeyPress:
+    if(e->xkey.state & meta_mask) {
+      KeySym ks=XLookupKeysym(&e->xkey,
+			      ((e->xkey.state & ShiftMask)?1:0)+
+			      ((e->xkey.state & switch_mask)?2:0));
+      void *item;
+      if((item=getitembyhotkey(ks)))
+	menuaction(item, NULL);
+    }
+    break;
+  }
+}
+
 static void incoming_event(struct module *m, struct mcmd_event *me)
 {
   extern void internal_broker(XEvent *);
@@ -437,7 +498,6 @@ static void handle_module_cmd(struct module *m, char *data, int data_len)
     break;
   case MCMD_ERRORMSG:
     if(data_len>0) {
-      extern char *free_screentitle;
       if(free_screentitle) free(free_screentitle);
       free_screentitle=malloc(data_len+1);
       if(free_screentitle==NULL)

--- a/module.h
+++ b/module.h
@@ -1,3 +1,16 @@
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+
+#ifdef AMIGAOS
+#define fd_set XTransFdset
+#undef FD_ZERO
+#undef FD_SET
+#define FD_ZERO XTransFdZero
+#define FD_SET XTransFdSet
+#define select XTransSelect
+#endif
+
 #define MCMD_NOP 1
 #define MCMD_GET_VERSION 2
 #define MCMD_SEND_EVENT 4
@@ -68,3 +81,12 @@ extern struct module {
   } broker;
   struct Item *menuitems;
 } *modules;
+
+extern char *free_screentitle;
+
+extern int dispatch_event_to_broker(XEvent *, unsigned long, struct module *);
+extern void internal_broker(XEvent *e);
+extern void flushmodules(void);
+extern void handle_module_input(fd_set *);
+extern void init_modules(void);
+extern void mod_menuselect(struct module *, int, int, int);

--- a/rc.c
+++ b/rc.c
@@ -4,11 +4,12 @@
 #include <X11/Xmu/CharSet.h>
 
 #include "alloc.h"
-#include "prefs.h"
 #include "drawinfo.h"
-#include "screen.h"
 #include "gram.tab.h"
 #include "icc.h"
+#include "prefs.h"
+#include "rc.h"
+#include "screen.h"
 #include "style.h"
 
 #ifdef AMIGAOS

--- a/rc.h
+++ b/rc.h
@@ -1,0 +1,1 @@
+extern void read_rc_file(char *filename, int manage_all);

--- a/screen.c
+++ b/screen.c
@@ -2,12 +2,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
-#include "prefs.h"
+#include "drawinfo.h"
+#include "events.h"
 #include "icc.h"
+#include "icon.h"
+#include "menu.h"
+#include "prefs.h"
+#include "screen.h"
 
 extern Display *dpy;
 extern Cursor wm_curs;
@@ -417,4 +419,37 @@ Scrn *getscreenbyrootext(Window w, int include_fs)
 Scrn *getscreenbyroot(Window w)
 {
   return getscreenbyrootext(w, 0);
+}
+
+void click_screendepth(Scrn *s, Time time)
+{
+  extern Scrn *mbdclick;
+  int status;
+
+  XSync(dpy, False);
+  status = XGrabPointer(dpy, s->menubardepth, True, ButtonPressMask|ButtonReleaseMask,
+                        GrabModeAsync, GrabModeAsync, False, None, time);
+  if (status != AlreadyGrabbed && status != GrabSuccess)
+    return;
+  mbdclick = s;
+  redrawmenubar(s, s->menubardepth);
+  for (;;) {
+    XEvent event;
+
+    event = get_drag_event();
+    if (event.type == ButtonRelease || event.type == ButtonPress) {
+      mbdclick = NULL;
+      redrawmenubar(s, s->menubardepth);
+      XUngrabPointer(dpy, event.xbutton.time);
+      if (event.type == ButtonPress)
+        return;
+      if (event.xbutton.x < 0 || event.xbutton.y < 0)
+        return;   /* pointer to left/top of button */
+      if (event.xbutton.x >= 23 || event.xbutton.y >= s->bh)
+        return;   /* pointer to right/bottom of button */
+      if(event.xbutton.window == s->menubardepth)
+        screentoback();
+      return;
+    }
+  }
 }

--- a/screen.h
+++ b/screen.h
@@ -2,6 +2,7 @@
 #define SCREEN_H
 
 #include "icon.h"
+#include "drawinfo.h"
 
 /*
  * Struct _Scrn - virtual desktop screen
@@ -39,17 +40,15 @@ typedef struct _Scrn {
 
 extern Scrn *scr;
 
-Scrn * get_front_scr(void);
-void set_front_scr(Scrn *s);
-
-extern void closescreen();
-extern Scrn * openscreen(char *, Window);
-extern void realizescreens();
-extern void screentoback();
-
-void closescreen();
-Scrn *openscreen(char *deftitle, Window root);
-void realizescreens();
-void screentoback();
+extern Scrn *get_front_scr(void);
+extern Scrn *getscreenbyroot(Window);
+extern Scrn *openscreen(char *, Window);
+extern Scrn *openscreen(char *deftitle, Window root);
+extern void assimilate(Window, int, int);
+extern void click_screendepth(Scrn *s, Time time);
+extern void closescreen(void);
+extern void realizescreens(void);
+extern void screentoback(void);
+extern void set_front_scr(Scrn *s);
 
 #endif


### PR DESCRIPTION
This refactoring "localizes" global state that was shared between different functions in different files into state local to a function. To do this, the following changes are made:

1. Abstract out different modes of operations (like dragging an icon, clicking (which involves two events: a button press and release), moving a window), which were all incompatible (the user can be only at one mode at a time) from the main event loop into various nested sub-event loops, one for each mode.

   That was done for click routines, writing click_close(), click_depth(), click_iconify(), click_screendepth(), and click_zoom(), all implementing a sub-event loop.  And for the interaction with the menu, by writing drag_menu(), another sub-event loop.

2. Events that should be handled unconditionally (that is, independent of the currently active mode, as if they are handled by a background process) have been abstracted out of the main loop into a new file, event.c.  All event loops (main event or sub-events) now #include's event.h.

3. For double-click, whose state was kept in several global variables at main.c, a single variable in the main loop routine keeps the previous button press event; and the new function is_double_click() compares it with the current button press event to check wether a double-click ocurred.

Also, as part of refactoring, to improve code quality, the following has been done:

1. Function declarations have been moved into header files.

   Missing headers, like frame.h, menu.h, rc.h, are created.

2. Some functions defined in a file but used only in another file had their definitions moved to where they are used.  For example, internal_broker() and lookup_keysyms() got moved from a exported function in main.c into a stactic function in module.c, because it was mostly used in the latter.

3. Sequence of declarations and `#include`s have been sorted alphabetically, for consistent coding style.

4. Braces in if-else clases have been applied consistently wherever i spotted them.  For example:

```
  if(foo) {
    make();
    free();
  } else if(bar)
    send();
  else {
    do();
    undo();
  }
```

   Got replaced by:

```
  if(foo) {
    make();
    free();
  } else if(bar) {
    send();
  } else {
    do();
    undo();
  }
```