### PR TITLE
 keep declarations for public functions in header files

### DIFF
--- a/client.c
+++ b/client.c
@@ -4,12 +4,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
+#include "drawinfo.h"
 #include "icc.h"
+#include "icon.h"
 #include "prefs.h"
+#include "screen.h"
 
 #ifdef AMIGAOS
 #include <pragmas/xlib_pragmas.h>
@@ -220,8 +220,6 @@ void getstate(Client *c)
 
 Client *createclient(Window w)
 {
-  extern void checkstyle(Client *c);
-
   XWindowAttributes attr;
   Client *c;
   int b = 0;

--- a/client.h
+++ b/client.h
@@ -41,18 +41,20 @@ typedef struct _Client {
 
 extern Client *clients;
 
+extern Client *createclient(Window);
 extern Client *getclient(Window);
 extern Client *getclientbyicon(Window);
-extern Client *createclient(Window);
-extern void rmclient(Client *);
+extern int screen_has_clients(void);
+extern void checksizehints(Client *);
 extern void flushclients(void);
-extern void scrsendconfig(struct _Scrn *);
-extern void sendconfig(Client *);
+extern void fullscreen(Client *, int);
 extern void getstate(Client *);
 extern void grav_map_frame_to_win(Client *, int, int, int *, int *);
 extern void grav_map_win_to_frame(Client *, int, int, int *, int *);
-extern void setclientstate(Client *, int);
 extern void reparent_client(struct _Scrn *s, Client *client);
-extern void fullscreen(Client *, int);
+extern void rmclient(Client *);
+extern void scrsendconfig(struct _Scrn *);
+extern void sendconfig(Client *);
+extern void setclientstate(Client *, int);
 
 #endif

--- a/diskobject.c
+++ b/diskobject.c
@@ -13,6 +13,7 @@
 
 #include "alloc.h"
 #include "drawinfo.h"
+#include "diskobject.h"
 #include "prefs.h"
 #include "screen.h"
 #include "libami.h"

--- a/diskobject.h
+++ b/diskobject.h
@@ -1,0 +1,7 @@
+struct IconPixmaps;
+
+extern void init_iconpalette(void);
+extern void load_do(const char *filename, struct IconPixmaps *ip);
+extern void set_sys_palette(void);
+
+extern int iconcolormask;

--- a/frame.c
+++ b/frame.c
@@ -8,14 +8,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
+#include "drawinfo.h"
+#include "frame.h"
 #include "icc.h"
-#include "prefs.h"
-#include "module.h"
+#include "icon.h"
 #include "libami.h"
+#include "menu.h"
+#include "module.h"
+#include "prefs.h"
+#include "screen.h"
 
 #ifdef AMIGAOS
 #include <pragmas/xlib_pragmas.h>
@@ -28,8 +30,6 @@ extern Display *dpy;
 extern XContext client_context, screen_context;
 extern Cursor wm_curs;
 extern int shape_extn;
-extern void redrawmenubar(Scrn *, Window);
-void reshape_frame(Client *c);
 
 Window creategadget(Client *c, Window p, int x, int y, int w, int h)
 {
@@ -729,7 +729,6 @@ raisebottommostclient(Scrn *scr)
 
 void gadgetunclicked(Client *c, XEvent *e)
 {
-  extern void adjusticon(Icon *);
   Window w;
   scr=c->scr;
   if((w=c->clicked)) {

--- a/frame.h
+++ b/frame.h
@@ -1,0 +1,16 @@
+struct _Client;
+struct _Scrn;
+
+extern void clickenter(void);
+extern void clickleave(void);
+extern void gadgetaborted(struct _Client *c);
+extern void gadgetclicked(struct _Client *c, Window w, XEvent *e);
+extern void gadgetunclicked(struct _Client *c, XEvent *e);
+extern void lowertopmostclient(struct _Scrn *scr);
+extern void raisebottommostclient(struct _Scrn *scr);
+extern void raiselowerclient(struct _Client *, int);
+extern void redraw(struct _Client *, Window);
+extern void redrawclient(struct _Client *);
+extern void reparent(struct _Client *);
+extern void reshape_frame(struct _Client *c);
+extern void resizeclientwindow(struct _Client *c, int, int);

--- a/icc.c
+++ b/icc.c
@@ -1,11 +1,13 @@
 #include <X11/Xatom.h>
 
+#include "client.h"
 #include "drawinfo.h"
-#include "screen.h"
+#include "frame.h"
 #include "icc.h"
 #include "icon.h"
-#include "style.h"
 #include "prefs.h"
+#include "screen.h"
+#include "style.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -15,8 +17,6 @@
 #include <pragmas/xlib_pragmas.h>
 extern struct Library *XLibBase;
 #endif
-
-extern void redraw(Client *, Window);
 
 Atom ATOMS[NATOMS];
 
@@ -214,9 +214,6 @@ void checkstyle(Client *c)
 
 void propertychange(Client *c, Atom a)
 {
-  extern void checksizehints(Client *);
-  extern void newicontitle(Client *);
-
   if(a==XA_WM_NAME) {
 #ifdef USE_FONTSETS
     XTextProperty prop;

--- a/icc.h
+++ b/icc.h
@@ -3,19 +3,6 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
-#include "client.h"
-
-extern void init_atoms(void);
-extern void setsupports(Window, Window);
-extern void sendcmessage(Window, Atom, long);
-extern void getproto(Client *c);
-extern void getwmstate(Client *c);
-extern void setwmstate(Client *c);
-extern void setstringprop(Window, Atom, char *);
-extern void propertychange(Client *, Atom);
-extern long _getprop(Window, Atom, Atom, long, char **);
-extern void getwflags(Client *);
-extern Window get_transient_for(Window);
 
 #define Pdelete 1
 #define Ptakefocus 2
@@ -61,6 +48,22 @@ enum {
 #undef  X
 };
 
+struct _Client;
+
 extern Atom ATOMS[NATOMS];
+
+extern Window get_transient_for(Window);
+extern long _getprop(Window, Atom, Atom, long, char **);
+extern void checkstyle(struct _Client *c);
+extern void getproto(struct _Client *c);
+extern void getwflags(struct _Client *);
+extern void getwmstate(struct _Client *c);
+extern void handle_client_message(struct _Client *, XClientMessageEvent *);
+extern void init_atoms(void);
+extern void propertychange(struct _Client *, Atom);
+extern void sendcmessage(Window, Atom, long);
+extern void setstringprop(Window, Atom, char *);
+extern void setsupports(Window, Window);
+extern void setwmstate(struct _Client *c);
 
 #endif

--- a/icon.c
+++ b/icon.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 
 #include "drawinfo.h"
+#include "diskobject.h"
 #include "screen.h"
 #include "icon.h"
 #include "client.h"
@@ -21,8 +22,6 @@ extern struct Library *XLibBase;
 extern Display *dpy;
 extern char *progname;
 extern XContext icon_context, client_context, screen_context;
-
-extern void init_iconpalette();
 
 #ifdef USE_FONTSETS
 XFontSet labelfontset;
@@ -172,7 +171,6 @@ void createdefaulticons()
   Window r;
   int x,y;
   unsigned int b,d;
-  extern void load_do(const char *, struct IconPixmaps *);
 
   init_iconpalette();
   load_do(prefs.defaulticon, &scr->default_tool_pms);
@@ -258,7 +256,6 @@ static void setstdiconicon(Icon *i, unsigned int *w, unsigned int *h)
       Window r;
       int x,y;
       unsigned int b,d;
-      extern void load_do(const char *, struct IconPixmaps *);
       load_do(s->icon_name, &s->icon_pms);
       if(s->icon_pms.pm == None) {
 	fprintf(stderr, "%s: Cannot load icon \"%s\".\n",

--- a/icon.h
+++ b/icon.h
@@ -1,14 +1,18 @@
 #ifndef ICON_H
 #define ICON_H
 
-#include "client.h"
+#include <X11/Xutil.h>
+
 #include "libami.h"
 
 struct _Scrn;
+struct _Client;
+struct module;
+
 typedef struct _Icon {
   struct _Icon *next, *nextselected;
   struct _Scrn *scr;
-  Client *client;
+  struct _Client *client;
   struct module *module;
   Window parent, window, labelwin, innerwin;
   Pixmap iconpm, secondpm, maskpm;
@@ -28,18 +32,24 @@ struct IconPixmaps
   struct ColorStore cs, cs2;
 };
 
-extern void redrawicon(Icon *, Window);
-extern void rmicon(Icon *);
-extern void createicon(Client *);
-extern void createiconicon(Icon *i, XWMHints *);
-extern void destroyiconicon(Icon *);
-extern void cleanupicons();
-extern void createdefaulticons();
 extern void adjusticon(Icon *);
-extern void selecticon(Icon *);
-extern void deselecticon(Icon *);
-extern void free_icon_pms(struct IconPixmaps *pms);
-extern void iconify(Client *);
+extern void cleanupicons(void);
+extern void createdefaulticons(void);
+extern void createicon(struct _Client *);
+extern void createiconicon(Icon *i, XWMHints *);
 extern void deiconify(Icon *);
+extern void deselect_all_icons(struct _Scrn *);
+extern void deselecticon(Icon *);
+extern void destroyiconicon(Icon *);
+extern void free_icon_pms(struct IconPixmaps *pms);
+extern void iconify(struct _Client *);
+extern void newicontitle(struct _Client *);
+extern void redrawicon(Icon *, Window);
+extern void reparenticon(Icon *, struct _Scrn *, int, int);
+extern void rmicon(Icon *);
+extern void select_all_icons(struct _Scrn *i);
+extern void selecticon(Icon *);
+extern Icon *createappicon(struct module *m, Window p, char *name,
+                           Pixmap pm1, Pixmap pm2, Pixmap pmm, int x, int y);
 
 #endif

--- a/joke_fs.c
+++ b/joke_fs.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <X11/Xlib.h>
+#include <X11/Xresource.h>
 #include <X11/Xutil.h>
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>

--- a/launchermodule.c
+++ b/launchermodule.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xresource.h>
 #include "libami.h"
 #include "drawinfo.h"
 

--- a/launchermodule.c
+++ b/launchermodule.c
@@ -3,8 +3,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <X11/Xlib.h>
-#include <X11/Xutil.h>
 #include <X11/Xresource.h>
+#include <X11/Xutil.h>
 #include "libami.h"
 #include "drawinfo.h"
 

--- a/libami/drawinfo.h
+++ b/libami/drawinfo.h
@@ -61,5 +61,7 @@ struct DrawInfo
 
 extern void term_dri(struct DrawInfo *, Display *, Colormap);
 extern void init_dri(struct DrawInfo *, Display *, Window, Colormap, int);
+extern Status myXAllocNamedColor(Display *dpy, Colormap cmap, char *color_name,
+                                 XColor *screen_def, XColor *exact_def);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -36,14 +36,17 @@
 #include <locale.h>
 #endif
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
-#include "prefs.h"
-#include "module.h"
+#include "drawinfo.h"
+#include "frame.h"
 #include "icc.h"
+#include "icon.h"
 #include "libami.h"
+#include "menu.h"
+#include "module.h"
+#include "prefs.h"
+#include "rc.h"
+#include "screen.h"
 
 #ifdef AMIGAOS
 #include <pragmas/xlib_pragmas.h>
@@ -53,13 +56,6 @@ struct timeval {
   long tv_sec;
   long tv_usec;
 };
-
-#define fd_set XTransFdset
-#undef FD_ZERO
-#undef FD_SET
-#define FD_ZERO XTransFdZero
-#define FD_SET XTransFdSet
-#define select XTransSelect
 #endif
 
 #define HYSTERESIS 5
@@ -94,39 +90,7 @@ static Window *checkwins;
 static int shape_event_base, shape_error_base;
 static int server_grabs=0;
 static unsigned int meta_mask, switch_mask;
-
 static char **main_argv;
-
-extern Scrn *mbdclick, *mbdscr;
-
-extern void reparent(Client *);
-extern void redraw(Client *, Window);
-extern void redrawclient(Client *);
-extern void redrawmenubar(Scrn *, Window);
-extern void resizeclientwindow(Client *c, int, int);
-extern void gadgetclicked(Client *c, Window w, XEvent *e);
-extern void gadgetunclicked(Client *c, XEvent *e);
-extern void gadgetaborted(Client *c);
-extern void clickenter(void);
-extern void clickleave(void);
-extern void menu_on(void);
-extern void menu_off(void);
-extern void menubar_enter(Window);
-extern void menubar_leave(Window);
-extern void *getitembyhotkey(KeySym);
-extern void menuaction(void *);
-extern Scrn *getscreenbyroot(Window);
-extern void assimilate(Window, int, int);
-extern void deselect_all_icons(Scrn *);
-extern void reparenticon(Icon *, Scrn *, int, int);
-extern void handle_client_message(Client *, XClientMessageEvent *);
-extern void handle_module_input(fd_set *);
-extern int dispatch_event_to_broker(XEvent *, unsigned long, struct module *);
-extern void reshape_frame(Client *c);
-extern void read_rc_file(char *filename, int manage_all);
-extern void init_modules();
-extern void flushmodules();
-extern void raiselowerclient(Client *, int);
 
 #ifndef AMIGAOS
 void restart_amiwm()
@@ -942,7 +906,7 @@ void internal_broker(XEvent *e)
 			      ((e->xkey.state & switch_mask)?2:0));
       void *item;
       if((item=getitembyhotkey(ks)))
-	menuaction(item);
+	menuaction(item, NULL);
     }
     break;
   }
@@ -966,7 +930,6 @@ static void update_clock(void *dontcare)
 static void cleanup()
 {
   int sc;
-  extern void free_prefs();
   struct coevent *e;
   flushmodules();
   flushclients();
@@ -1265,7 +1228,6 @@ int main(int argc, char *argv[])
 	  c = NULL;
 	if(c && event.xconfigurerequest.window==c->window &&
 	   c->parent!=c->scr->root) {
-	  extern void resizeclientwindow(Client *c, int, int);
 	  if(event.xconfigurerequest.value_mask&CWBorderWidth)
 	    c->old_bw=event.xconfigurerequest.border_width;
 	  resizeclientwindow(c, (event.xconfigurerequest.value_mask&CWWidth)?

--- a/menu.c
+++ b/menu.c
@@ -8,11 +8,13 @@
 #endif
 
 #include "alloc.h"
+#include "client.h"
 #include "drawinfo.h"
+#include "icon.h"
+#include "menu.h"
+#include "module.h"
 #include "prefs.h"
 #include "screen.h"
-#include "client.h"
-#include "icon.h"
 #include "version.h"
 
 #define ABOUT_STRING(LF) \
@@ -44,10 +46,7 @@ extern Cursor wm_curs;
 extern XContext screen_context, client_context;
 extern Client *activeclient;
 
-extern void select_all_icons(Scrn *i);
-extern void mod_menuselect(struct module *, int, int, int);
 extern void setfocus(Window);
-extern void flushmodules();
 extern void wberror(Scrn *, char *);
 
 Scrn *mbdclick=NULL, *mbdscr=NULL;
@@ -761,7 +760,6 @@ void menu_on()
 void menuaction(struct Item *i, struct Item *si)
 {
   extern void restart_amiwm(void);
-  extern int screen_has_clients(void);
   struct Menu *m;
   struct Item *mi;
   struct ToolItem *ti;

--- a/menu.h
+++ b/menu.h
@@ -1,0 +1,17 @@
+struct Item;
+struct _Scrn;
+struct module;
+
+extern void createmenubar(void);
+extern void disown_item_chain(struct module *m, struct Item *i);
+extern void menu_off(void);
+extern void menu_on(void);
+extern void menuaction(struct Item *i, struct Item *si);
+extern void menubar_enter(Window);
+extern void menubar_leave(Window);
+extern void redrawmenubar(struct _Scrn *, Window);
+extern struct Item *getitembyhotkey(KeySym);
+extern struct Item *own_items(struct module *m, struct _Scrn *s, int menu,
+                              int item, int sub, struct Item *c);
+
+extern struct _Scrn *mbdclick, *mbdscr;

--- a/module.c
+++ b/module.c
@@ -23,12 +23,15 @@
 #include <X11/Xlib.h>
 
 #include "alloc.h"
-#include "drawinfo.h"
-#include "screen.h"
-#include "prefs.h"
-#include "module.h"
 #include "client.h"
+#include "diskobject.h"
+#include "drawinfo.h"
+#include "frame.h"
 #include "icon.h"
+#include "menu.h"
+#include "module.h"
+#include "prefs.h"
+#include "screen.h"
 #include "version.h"
 
 extern XContext client_context, icon_context, screen_context;
@@ -38,16 +41,7 @@ extern Display *dpy;
 
 extern void add_fd_to_set(int);
 extern void remove_fd_from_set(int);
-
-extern void raiselowerclient(Client *, int);
 extern void wberror(Scrn *, char *);
-
-extern Icon *createappicon(struct module *, Window, char *,
-			   Pixmap, Pixmap, Pixmap, int, int);
-
-extern struct Item *own_items(struct module *, Scrn *,
-			       int, int, int, struct Item *);
-extern void disown_item_chain(struct module *, struct Item *);
 
 struct module *modules = NULL;
 
@@ -331,13 +325,8 @@ void mod_menuselect(struct module *m, int menu, int item, int subitem)
 	  menu, item, subitem, (int)m->pid);
 }
 
-extern void lowertopmostclient(Scrn *scr);
-extern void raisebottommostclient(Scrn *scr);
-
 static void handle_module_cmd(struct module *m, char *data, int data_len)
 {
-  extern Scrn *getscreen(Window);
-  extern int iconcolormask;
   XID id=m->mcmd.id;
   Client *c;
 

--- a/module.h
+++ b/module.h
@@ -1,3 +1,16 @@
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+
+#ifdef AMIGAOS
+#define fd_set XTransFdset
+#undef FD_ZERO
+#undef FD_SET
+#define FD_ZERO XTransFdZero
+#define FD_SET XTransFdSet
+#define select XTransSelect
+#endif
+
 #define MCMD_NOP 1
 #define MCMD_GET_VERSION 2
 #define MCMD_SEND_EVENT 4
@@ -68,3 +81,9 @@ extern struct module {
   } broker;
   struct Item *menuitems;
 } *modules;
+
+extern int dispatch_event_to_broker(XEvent *, unsigned long, struct module *);
+extern void flushmodules(void);
+extern void handle_module_input(fd_set *);
+extern void init_modules(void);
+extern void mod_menuselect(struct module *, int, int, int);

--- a/rc.c
+++ b/rc.c
@@ -4,11 +4,13 @@
 #include <X11/Xmu/CharSet.h>
 
 #include "alloc.h"
-#include "prefs.h"
 #include "drawinfo.h"
-#include "screen.h"
+#include "diskobject.h"
 #include "gram.tab.h"
 #include "icc.h"
+#include "prefs.h"
+#include "rc.h"
+#include "screen.h"
 #include "style.h"
 
 #ifdef AMIGAOS
@@ -16,7 +18,6 @@
 extern struct Library *Xmu1Base;
 #endif
 
-extern void set_sys_palette(void);
 extern int yyparse (void);
 
 struct prefs_struct prefs;

--- a/rc.h
+++ b/rc.h
@@ -1,0 +1,2 @@
+extern void read_rc_file(char *filename, int manage_all);
+extern void free_prefs(void);

--- a/screen.c
+++ b/screen.c
@@ -2,12 +2,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "drawinfo.h"
-#include "screen.h"
-#include "icon.h"
 #include "client.h"
-#include "prefs.h"
+#include "drawinfo.h"
+#include "frame.h"
 #include "icc.h"
+#include "icon.h"
+#include "menu.h"
+#include "prefs.h"
+#include "screen.h"
 
 extern Display *dpy;
 extern Cursor wm_curs;
@@ -19,9 +21,6 @@ extern XFontStruct *labelfont;
 #endif
 extern char *progname;
 extern XContext screen_context, client_context, vroot_context;
-
-extern void createmenubar();
-extern void reparent(Client *);
 
 static Scrn *_front = NULL;
 Scrn *scr = NULL;

--- a/screen.h
+++ b/screen.h
@@ -1,6 +1,7 @@
 #ifndef SCREEN_H
 #define SCREEN_H
 
+#include "drawinfo.h"
 #include "icon.h"
 
 /*

--- a/screen.h
+++ b/screen.h
@@ -39,17 +39,15 @@ typedef struct _Scrn {
 
 extern Scrn *scr;
 
-Scrn * get_front_scr(void);
-void set_front_scr(Scrn *s);
-
-extern void closescreen();
-extern Scrn * openscreen(char *, Window);
-extern void realizescreens();
-extern void screentoback();
-
-void closescreen();
-Scrn *openscreen(char *deftitle, Window root);
-void realizescreens();
-void screentoback();
+extern void assimilate(Window, int, int);
+extern Scrn *get_front_scr(void);
+extern Scrn *getscreenbyroot(Window);
+extern Scrn *getscreen(Window);
+extern Scrn *openscreen(char *, Window);
+extern Scrn *openscreen(char *deftitle, Window root);
+extern void closescreen(void);
+extern void realizescreens(void);
+extern void screentoback(void);
+extern void set_front_scr(Scrn *s);
 
 #endif


### PR DESCRIPTION
- Move declarations for shared functions from *.c files into *.h files.
- Create missing header files (frame.h, menu.h, etc).
- Sort function declarations alphabetically (for consistent code style).

Lots of files got changed, but it was just adding "#include" lines and removing function prototype lines from *.c files; and adding function prototypes into *.h, etc.  Very small changes; but very small changes everywhere.
